### PR TITLE
Always target cluster local gateway for RewriteHost rules

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -214,7 +214,7 @@ func makeVirtualServiceRoute(ctx context.Context, hosts sets.String, http *v1alp
 		weights = []*istiov1alpha3.HTTPRouteDestination{{
 			Weight: 100,
 			Destination: &istiov1alpha3.Destination{
-				Host: gatewayServiceURLFromContext(ctx, visibility),
+				Host: privateGatewayServiceURLFromContext(ctx),
 			},
 		}}
 	}
@@ -319,23 +319,6 @@ func getPublicIngressRules(i *v1alpha1.Ingress) []v1alpha1.IngressRule {
 	}
 
 	return result
-}
-
-func gatewayServiceURLFromContext(ctx context.Context, visibility v1alpha1.IngressVisibility) string {
-	if visibility == v1alpha1.IngressVisibilityExternalIP {
-		return publicGatewayServiceURLFromContext(ctx)
-	}
-
-	return privateGatewayServiceURLFromContext(ctx)
-}
-
-func publicGatewayServiceURLFromContext(ctx context.Context) string {
-	cfg := config.FromContext(ctx).Istio
-	if len(cfg.IngressGateways) > 0 {
-		return cfg.IngressGateways[0].ServiceURL
-	}
-
-	return ""
 }
 
 func privateGatewayServiceURLFromContext(ctx context.Context) string {

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -785,8 +785,8 @@ func TestMakeVirtualServiceRoute_RewriteHost(t *testing.T) {
 	}
 	ctx := config.ToContext(context.Background(), &config.Config{
 		Istio: &config.Istio{
-			IngressGateways: []config.Gateway{{
-				ServiceURL: "the-public-gateway.svc.url",
+			LocalGateways: []config.Gateway{{
+				ServiceURL: "the-local-gateway.svc.url",
 			}},
 		},
 	})
@@ -808,7 +808,7 @@ func TestMakeVirtualServiceRoute_RewriteHost(t *testing.T) {
 		},
 		Route: []*istiov1alpha3.HTTPRouteDestination{{
 			Destination: &istiov1alpha3.Destination{
-				Host: "the-public-gateway.svc.url",
+				Host: "the-local-gateway.svc.url",
 			},
 			Weight: 100,
 		}},


### PR DESCRIPTION
Following on from @ZhiminXiang's [suggestion](https://github.com/knative-sandbox/net-istio/pull/174#discussion_r456184487) in  https://github.com/knative-sandbox/net-istio/pull/174, better to always target the cluster local gateway in RewriteHost rules, since the user may want to set up https/authentication on the external gateway that might otherwise get in the way of the request.

/assign @ZhiminXiang @tcnghia 