### PR TITLE
[master] golang format tools

### DIFF
--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -1251,7 +1251,7 @@ func TestListProbeTargets(t *testing.T) {
 			URLs: []*url.URL{
 				{Scheme: "http", Host: "foo.bar.com:80"}},
 		}},
-	},{
+	}, {
 		name: "local gateways",
 		localGateways: []config.Gateway{{
 			Name:      "local-gateway",


### PR DESCRIPTION
<!--[master] golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party | grep -v .pb.go | grep -v wire_gen.go)`
/assign tcnghia
/cc tcnghia
