### PR TITLE
Run tests with NodeLocalDNS enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	knative.dev/networking v0.0.0-20200812200006-4d518e76538a
 	knative.dev/pkg v0.0.0-20200812224206-44c860147a87
-	knative.dev/test-infra v0.0.0-20200811195106-afcd1747545f
+	knative.dev/test-infra v0.0.0-20200813190506-094a2b6eb665
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1850,8 +1850,8 @@ knative.dev/test-infra v0.0.0-20200519015156-82551620b0a9/go.mod h1:A5b2OAXTOeHT
 knative.dev/test-infra v0.0.0-20200707183444-aed09e56ddc7/go.mod h1:RjYAhXnZqeHw9+B0zsbqSPlae0lCvjekO/nw5ZMpLCs=
 knative.dev/test-infra v0.0.0-20200811030605-72f8c9f3e933 h1:1nfmLI9iQ87ygMeKGLREhH+2KYa6XX/e6enu0PsasHY=
 knative.dev/test-infra v0.0.0-20200811030605-72f8c9f3e933/go.mod h1:Pmg2c7Z7q7BGFUV/GOpU5BlrD3ePJft4MPqx8AYBplc=
-knative.dev/test-infra v0.0.0-20200811195106-afcd1747545f h1:VLGSL2XW7xty70B+SWezfmi2KHb3/OaJW7DtFvTr5BU=
-knative.dev/test-infra v0.0.0-20200811195106-afcd1747545f/go.mod h1:Pmg2c7Z7q7BGFUV/GOpU5BlrD3ePJft4MPqx8AYBplc=
+knative.dev/test-infra v0.0.0-20200813190506-094a2b6eb665 h1:LJrtcS8qMmMj1cSeu0HPRq0l3hKbPDI45r9DvfUW2k4=
+knative.dev/test-infra v0.0.0-20200813190506-094a2b6eb665/go.mod h1:Pmg2c7Z7q7BGFUV/GOpU5BlrD3ePJft4MPqx8AYBplc=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
@@ -221,7 +221,7 @@ function create_test_cluster() {
 
   # Create cluster and run the tests
   create_test_cluster_with_retries "${E2E_SCRIPT} ${test_cmd_args}" \
-    "${CLUSTER_CREATION_ARGS[@]}" "${extra_flags[@]}"
+    "${CLUSTER_CREATION_ARGS[@]}" "${extra_flags[@]}" "${EXTRA_KUBETEST2_FLAGS[@]}"
   local result="$?"
   # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
   set +o errexit
@@ -378,6 +378,7 @@ E2E_SCRIPT=""
 E2E_CLUSTER_VERSION="latest"
 GKE_ADDONS=""
 EXTRA_CLUSTER_CREATION_FLAGS=()
+EXTRA_KUBETEST2_FLAGS=()
 E2E_SCRIPT_CUSTOM_FLAGS=()
 
 # Parse flags and initialize the test cluster.
@@ -414,6 +415,7 @@ function initialize() {
           --gcp-project) GCP_PROJECT=$1 ;;
           --cluster-version) E2E_CLUSTER_VERSION=$1 ;;
           --cluster-creation-flag) EXTRA_CLUSTER_CREATION_FLAGS+=("$1") ;;
+          --kubetest2-flag) EXTRA_KUBETEST2_FLAGS+=("$1") ;;
           *) abort "unknown option ${parameter}" ;;
         esac
     esac
@@ -431,12 +433,17 @@ function initialize() {
 
   (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
 
-  (( SKIP_ISTIO_ADDON )) || GKE_ADDONS="--addons=Istio"
+  if (( SKIP_ISTIO_ADDON )); then
+    GKE_ADDONS="--addons=NodeLocalDNS"
+  else
+    GKE_ADDONS="--addons=Istio,NodeLocalDNS"
+  fi
 
   readonly RUN_TESTS
   readonly GCP_PROJECT
   readonly IS_BOSKOS
   readonly EXTRA_CLUSTER_CREATION_FLAGS
+  readonly EXTRA_KUBETEST2_FLAGS
   readonly SKIP_KNATIVE_SETUP
   readonly SKIP_TEARDOWNS
   readonly GKE_ADDONS

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -994,7 +994,7 @@ knative.dev/pkg/webhook/certificates/resources
 knative.dev/pkg/webhook/configmaps
 knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/defaulting
-# knative.dev/test-infra v0.0.0-20200811195106-afcd1747545f
+# knative.dev/test-infra v0.0.0-20200813190506-094a2b6eb665
 ## explicit
 knative.dev/test-infra/scripts
 knative.dev/test-infra/tools/dep-collector


### PR DESCRIPTION
This pulls in https://github.com/knative/test-infra/pull/2360 to reduce pressure on `kube-dns`.