### PR TITLE
Run 5 parallel invocations for KIngress conformance tests.

### DIFF
--- a/test/conformance/ingress_test.go
+++ b/test/conformance/ingress_test.go
@@ -19,11 +19,19 @@ limitations under the License.
 package conformance
 
 import (
+	"strconv"
 	"testing"
 
 	"knative.dev/networking/test/conformance/ingress"
 )
 
+const iterations = 5
+
 func TestIngressConformance(t *testing.T) {
-	ingress.RunConformance(t)
+	for i := 0; i < iterations; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			ingress.RunConformance(t)
+		})
+	}
 }


### PR DESCRIPTION
This will bring the load a bit  closer to the level of concurrency we see in Serving e2e tests.