### PR TITLE
Remove `-parallel=12` to match Serving e2e & increase test runs.

### DIFF
--- a/test/conformance/ingress_test.go
+++ b/test/conformance/ingress_test.go
@@ -25,7 +25,7 @@ import (
 	"knative.dev/networking/test/conformance/ingress"
 )
 
-const iterations = 11
+const iterations = 15
 
 func TestIngressConformance(t *testing.T) {
 	for i := 0; i < iterations; i++ {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -20,7 +20,6 @@ source $(dirname $0)/e2e-common.sh
 # Script entry point.
 initialize $@  --skip-istio-addon
 
-go_test_e2e -timeout=40m -parallel=12 \
-  ./test/conformance || fail_test
+go_test_e2e -timeout=60m ./test/conformance || fail_test
 
 success


### PR DESCRIPTION
I'm trying to reproduce the flakiness of Istio 1.5 when running conformance tests.