### PR TITLE
Add new local Gateway sharing same deployment as ingress Gateway.

### DIFF
--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -33,3 +33,39 @@ spec:
       protocol: HTTP
     hosts:
     - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: knative-local-gateway
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 8081
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: knative-local-gateway
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  type: ClusterIP
+  selector:
+    istio: ingressgateway
+  ports:
+    - name: http2
+      port: 80
+      targetPort: 8081

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -41,8 +41,11 @@ const (
 	// KnativeIngressGateway is the name of the ingress gateway
 	KnativeIngressGateway = "knative-ingress-gateway"
 
-	// ClusterLocalGateway is the name of the local gateway
+	// ClusterLocalGateway is the name of the local gateway (will be deprecated)
 	ClusterLocalGateway = "cluster-local-gateway"
+
+	// KnativeLocalGateway is the name of the local gateway (will be promoted)
+	KnativeLocalGateway = "knative-local-gateway"
 )
 
 func defaultIngressGateways() []Gateway {
@@ -59,6 +62,11 @@ func defaultLocalGateways() []Gateway {
 		Namespace: system.Namespace(),
 		Name:      ClusterLocalGateway,
 		ServiceURL: fmt.Sprintf(ClusterLocalGateway+".istio-system.svc.%s",
+			network.GetClusterDomainName()),
+	}, {
+		Namespace: system.Namespace(),
+		Name:      KnativeLocalGateway,
+		ServiceURL: fmt.Sprintf(KnativeLocalGateway+".knative-serving.svc.%s",
 			network.GetClusterDomainName()),
 	}}
 }


### PR DESCRIPTION
Related to https://github.com/knative-sandbox/net-istio/issues/212.

The idea is to create a new `Gateway` named `knative-local-gateway` (more consistent with `knative-ingress-gateway` than `cluster-local-gateway`). This Gateway binds to the same Envoy Pods as the Istio ingress Gateway, but on a different port (`8081` because `8080` is already used by Istio). There is a corresponding Kubernetes Service mapping named `knative-local-gateway` living in `knative-serving` (cleaner than `cluster-local-gateway` living in `istio-system`) mapping port `80` to port `8081`.
`knative-local-gateway` is added to the default Istio Gateways, this way the VirtualServices of local Knative Services bind to it (i.e. ready to serve traffic), but because the `KIngress` status uses the first local Gateway in its status, the Services of type `ExternalName` still point to `cluster-local-gateway` (and it is not accessible to external requests since `8081` is not exposed through the `LoadBalancer` Service).

Effectively, this is a no-op, but in the next release we can remove reference to `cluster-local-gateway` in default `config-istio` and there will be no traffic interruption and the requests will flow to `knative-local-gateway`.

After that, everything related to `cluster-local-gateway` can be safely removed, including the `Deployment`, which is the end goal here.

/hold
/assign @tcnghia 
/assign @ZhiminXiang 
Let me know what you think.
