### PR TITLE
Add support for -short

### DIFF
--- a/test/conformance/ingress_test.go
+++ b/test/conformance/ingress_test.go
@@ -33,5 +33,10 @@ func TestIngressConformance(t *testing.T) {
 			t.Parallel()
 			ingress.RunConformance(t)
 		})
+
+		// With `-short` only run a single iteration.
+		if testing.Short() {
+			break
+		}
 	}
 }


### PR DESCRIPTION
Instead of running N iterations, just run one when `-short` is passed.