### PR TITLE
Include HEAD commit hash in release YAML.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -53,7 +53,8 @@ function build_release() {
   # Assemble the release
   for yaml in "${!RELEASES[@]}"; do
     echo "Assembling Knative net-istio - ${yaml}"
-    echo "" > ${yaml}
+    echo "# Generated when HEAD was $(git rev-parse HEAD)" > ${yaml}
+    echo "#" >> ${yaml}
     for component in ${RELEASES[${yaml}]}; do
       echo "---" >> ${yaml}
       echo "# ${component}" >> ${yaml}


### PR DESCRIPTION
First part of https://github.com/knative/serving/issues/9420.

This way we can clone `net-istio` in `serving` at the exact point `net-istio.yaml` was generated.
No more hard-coding in the scripts.

/assign @tcnghia 