### PR TITLE
Rename and tweak Kind profiles.

### DIFF
--- a/third_party/istio-latest/istio-kind-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-mesh.yaml
@@ -17,22 +17,34 @@ kind: IstioOperator
 spec:
   values:
     global:
+      mtls:
+        enabled: true
+        auto: false
       proxy:
-        autoInject: disabled
+        autoInject: enabled
+        accessLogFile: "/dev/stdout"
+        accessLogEncoding: 'JSON'
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens
       jwtPolicy: first-party-jwt
     pilot:
-      autoscaleMin: 3
-      autoscaleMax: 10
+      autoscaleMin: 1
+      autoscaleMax: 3
       cpu:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 2
-        autoscaleMax: 5
+        autoscaleMin: 1
+        autoscaleMax: 3
         type: NodePort
+    sidecarInjectorWebhook:
+      rewriteAppHTTPProbe: true
+
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        TERMINATION_DRAIN_DURATION_SECONDS: "20"
 
   addonComponents:
     pilot:
@@ -46,12 +58,9 @@ spec:
         enabled: true
         k8s:
           resources:
-            limits:
-              cpu: 3000m
-              memory: 2048Mi
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 256Mi
       - name: cluster-local-gateway
         enabled: true
         label:
@@ -59,12 +68,9 @@ spec:
           app: cluster-local-gateway
         k8s:
           resources:
-            limits:
-              cpu: 3000m
-              memory: 2048Mi
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 256Mi
           service:
             type: ClusterIP
             ports:

--- a/third_party/istio-latest/istio-kind-no-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh.yaml
@@ -17,34 +17,22 @@ kind: IstioOperator
 spec:
   values:
     global:
-      mtls:
-        enabled: true
-        auto: false
       proxy:
-        autoInject: enabled
-        accessLogFile: "/dev/stdout"
-        accessLogEncoding: 'JSON'
+        autoInject: disabled
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens
       jwtPolicy: first-party-jwt
     pilot:
-      autoscaleMin: 3
-      autoscaleMax: 10
+      autoscaleMin: 1
+      autoscaleMax: 3
       cpu:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 2
-        autoscaleMax: 5
+        autoscaleMin: 1
+        autoscaleMax: 3
         type: NodePort
-    sidecarInjectorWebhook:
-      rewriteAppHTTPProbe: true
-
-  meshConfig:
-    defaultConfig:
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
 
   addonComponents:
     pilot:
@@ -58,12 +46,9 @@ spec:
         enabled: true
         k8s:
           resources:
-            limits:
-              cpu: 3000m
-              memory: 2048Mi
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 256Mi
       - name: cluster-local-gateway
         enabled: true
         label:
@@ -71,12 +56,9 @@ spec:
           app: cluster-local-gateway
         k8s:
           resources:
-            limits:
-              cpu: 3000m
-              memory: 2048Mi
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 256Mi
           service:
             type: ClusterIP
             ports:

--- a/third_party/istio-stable/istio-kind-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-mesh.yaml
@@ -1838,7 +1838,7 @@ metadata:
     istio: cluster-local-gateway
     release: RELEASE-NAME
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: cluster-local-gateway
@@ -1906,7 +1906,7 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 250m
+              cpu: 100m
               memory: 256Mi
           env:
           - name: NODE_NAME
@@ -2120,12 +2120,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
-            limits:
-              cpu: 3000m
-              memory: 2048Mi
             requests:
-              cpu: 3000m
-              memory: 2048Mi
+              cpu: 100m
+              memory: 256Mi
           env:
           - name: NODE_NAME
             valueFrom:
@@ -2526,12 +2523,9 @@ spec:
         - name: GOMAXPROCS
           value: "6"
         resources:
-          limits:
-            cpu: 4800m
-            memory: 4G
           requests:
-            cpu: 1000m
-            memory: 1G
+            cpu: 100m
+            memory: 256G
         volumeMounts:
         - name: istio-certs
           mountPath: /etc/certs
@@ -2677,8 +2671,8 @@ spec:
             value: "false"
           resources:
             requests:
-              cpu: 3000m
-              memory: 2048Mi
+              cpu: 100m
+              memory: 256Mi
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
@@ -2723,9 +2717,6 @@ spec:
           - name: SDS_ENABLED
             value: "false"
           resources:
-            limits:
-              cpu: 2000m
-              memory: 1024Mi
             requests:
               cpu: 100m
               memory: 128Mi
@@ -3000,8 +2991,8 @@ metadata:
     app: istio-ingressgateway
     istio: ingressgateway
 spec:
-  maxReplicas: 4
-  minReplicas: 2
+  maxReplicas: 3
+  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -3024,7 +3015,7 @@ metadata:
     heritage: Helm
     release: RELEASE-NAME
 spec:
-    maxReplicas: 5
+    maxReplicas: 3
     minReplicas: 1
     scaleTargetRef:
       apiVersion: apps/v1
@@ -3048,7 +3039,7 @@ metadata:
     heritage: Helm
     release: RELEASE-NAME
 spec:
-    maxReplicas: 5
+    maxReplicas: 3
     minReplicas: 1
     scaleTargetRef:
       apiVersion: apps/v1
@@ -3072,8 +3063,8 @@ metadata:
     heritage: Helm
     release: RELEASE-NAME
 spec:
-  maxReplicas: 5
-  minReplicas: 2
+  maxReplicas: 3
+  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/third_party/istio-stable/istio-kind-no-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh.yaml
@@ -1019,9 +1019,6 @@ spec:
           image: "docker.io/istio/node-agent-k8s:1.5.7"
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              cpu: 2000m
-              memory: 1024Mi
             requests:
               cpu: 100m
               memory: 128Mi
@@ -1083,12 +1080,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
-            limits:
-              cpu: 2000m
-              memory: 1024Mi
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 256Mi
           env:
           - name: NODE_NAME
             valueFrom:
@@ -1219,7 +1213,7 @@ metadata:
     istio: cluster-local-gateway
     release: RELEASE-NAME
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: cluster-local-gateway
@@ -1287,8 +1281,8 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 256Mi
           env:
           - name: NODE_NAME
             valueFrom:
@@ -1476,8 +1470,8 @@ spec:
             value: "false"
           resources:
             requests:
-              cpu: 1000m
-              memory: 1024Mi
+              cpu: 100m
+              memory: 256Mi
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
@@ -1625,8 +1619,8 @@ metadata:
     app: istio-ingressgateway
     istio: ingressgateway
 spec:
-  maxReplicas: 5
-  minReplicas: 2
+  maxReplicas: 3
+  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -1649,7 +1643,7 @@ metadata:
     heritage: Helm
     release: RELEASE-NAME
 spec:
-  maxReplicas: 5
+  maxReplicas: 3
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
In #293, I introduced profiles exposing the Ingress Service has a Node Port so that it would work with the Kind E2E running in a GitHub Action. GitHub Actions have only 2 cores, so the `resource.requests` and `replicaCount` need to be scaled way down in order for Istio to be deployed successfully on Kind (https://github.com/knative/serving/pull/9471).

Also, this renames the profiles to make the intent clearer.