### PR TITLE
Tune CodeCov down a little bit.

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,3 +1,16 @@
+coverage:
+  # Commit status https://docs.codecov.io/docs/commit-status are used
+  # to block PR based on coverage threshold.
+  status:
+    project:
+      default:
+        target: 80
+        threshold: 1%
+    patch:
+      # Disable the coverage threshold of the patch, so that PRs are
+      # only failing because of overall project coverage threshold.
+      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
+      default: false
 ignore:
   - "**/zz_generated*.go" # Ignore generated files.
   - "pkg/client"


### PR DESCRIPTION
Currently CodeCov is too strict causing harmless PRs (update deps) to be flagged. This mirrors what we have in Serving and tune things down a little bit.

/assign @mattmoor 
