### PR TITLE
Remove deprecated fields.

### DIFF
--- a/third_party/istio-latest/extra/global-mtls.yaml
+++ b/third_party/istio-latest/extra/global-mtls.yaml
@@ -1,0 +1,8 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: STRICT

--- a/third_party/istio-latest/install-istio.sh
+++ b/third_party/istio-latest/install-istio.sh
@@ -29,18 +29,9 @@ tar xzf ${ISTIO_TARBALL}
 # Install Istio
 ./istio-${ISTIO_VERSION}/bin/istioctl install -f "$(dirname $0)/$1"
 
-# Enable mTLS STRICT
-if [[ -n "$KIND" ]]; then
-  cat <<EOF | kubectl apply -f -
-  apiVersion: "security.istio.io/v1beta1"
-  kind: "PeerAuthentication"
-  metadata:
-    name: "default"
-    namespace: "istio-system"
-  spec:
-    mtls:
-      mode: STRICT
-EOF
+# Enable mTLS STRICT in mesh mode
+if [[ $MESH -eq 1 ]]; then
+  kubectl apply -f "$(dirname $0)/extra/global-mtls.yaml"
 fi
 
 # Clean up

--- a/third_party/istio-latest/install-istio.sh
+++ b/third_party/istio-latest/install-istio.sh
@@ -29,6 +29,20 @@ tar xzf ${ISTIO_TARBALL}
 # Install Istio
 ./istio-${ISTIO_VERSION}/bin/istioctl install -f "$(dirname $0)/$1"
 
+# Enable mTLS STRICT
+if [[ -n "$KIND" ]]; then
+  cat <<EOF | kubectl apply -f -
+  apiVersion: "security.istio.io/v1beta1"
+  kind: "PeerAuthentication"
+  metadata:
+    name: "default"
+    namespace: "istio-system"
+  spec:
+    mtls:
+      mode: STRICT
+EOF
+fi
+
 # Clean up
 rm -rf istio-${ISTIO_VERSION}
 rm ${ISTIO_TARBALL}

--- a/third_party/istio-latest/istio-ci-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-mesh.yaml
@@ -17,13 +17,8 @@ kind: IstioOperator
 spec:
   values:
     global:
-      mtls:
-        enabled: true
-        auto: false
       proxy:
         autoInject: enabled
-        accessLogFile: "/dev/stdout"
-        accessLogEncoding: 'JSON'
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens

--- a/third_party/istio-latest/istio-kind-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-mesh.yaml
@@ -17,13 +17,8 @@ kind: IstioOperator
 spec:
   values:
     global:
-      mtls:
-        enabled: true
-        auto: false
       proxy:
         autoInject: enabled
-        accessLogFile: "/dev/stdout"
-        accessLogEncoding: 'JSON'
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens


### PR DESCRIPTION
These prevents `latest` from being installed.