### PR TITLE
Specify port for rewrite host destination

### DIFF
--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -40,6 +40,9 @@ import (
 	"knative.dev/pkg/tracker"
 )
 
+// GatewayHTTPPort is the HTTP port the gateways listen on.
+const GatewayHTTPPort = 80
+
 var httpServerPortName = "http-server"
 
 var gatewayGvk = v1alpha3.SchemeGroupVersion.WithKind("Gateway")
@@ -311,7 +314,7 @@ func MakeHTTPServer(httpProtocol network.HTTPProtocol, hosts []string) *istiov1a
 		Hosts: hosts,
 		Port: &istiov1alpha3.Port{
 			Name:     httpServerPortName,
-			Number:   80,
+			Number:   GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 	}

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -215,7 +215,7 @@ func makeVirtualServiceRoute(ctx context.Context, hosts sets.String, http *v1alp
 			Destination: &istiov1alpha3.Destination{
 				Host: privateGatewayServiceURLFromContext(ctx),
 				Port: &istiov1alpha3.PortSelector{
-					Number: 80,
+					Number: GatewayHTTPPort,
 				},
 			},
 		}}

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -214,6 +214,9 @@ func makeVirtualServiceRoute(ctx context.Context, hosts sets.String, http *v1alp
 			Weight: 100,
 			Destination: &istiov1alpha3.Destination{
 				Host: privateGatewayServiceURLFromContext(ctx),
+				Port: &istiov1alpha3.PortSelector{
+					Number: 80,
+				},
 			},
 		}}
 	}

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -627,6 +627,9 @@ func TestMakeVirtualServiceRoute_RewriteHost(t *testing.T) {
 		Route: []*istiov1alpha3.HTTPRouteDestination{{
 			Destination: &istiov1alpha3.Destination{
 				Host: "the-local-gateway.svc.url",
+				Port: &istiov1alpha3.PortSelector{
+					Number: 80,
+				},
 			},
 			Weight: 100,
 		}},
@@ -647,7 +650,6 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 		},
 		Splits: []v1alpha1.IngressBackendSplit{{
 			IngressBackend: v1alpha1.IngressBackend{
-
 				ServiceNamespace: "test-ns",
 				ServiceName:      "revision-service",
 				ServicePort:      intstr.FromInt(80),


### PR DESCRIPTION
When the incoming request is using https, failing to specify the destination port means we end up re-running the request against port 443 on the cluster-local-gateway which is not what we want.  We see errors like "`Connection #0 to host blah-blah left intact
upstream connect error or disconnect/reset before headers. reset reason: connection failure`" when using a rewrite rule over https.  

Explicitly specifying port 80 for the destination fixes our issue (I think the hard-coding of 80 is fine here because this is the only port the cluster local gateway can possibly be on).

This matches the way we already set a port for regular non-rewrite-host splits (see [virtual_service.go#L189](https://github.com/knative-sandbox/net-istio/blob/9fb6d8eee0f12b6cc3bfbc34b646246ef45eafd4/pkg/reconciler/ingress/resources/virtual_service.go#L189)).

/assign @tcnghia @nak3 