### PR TITLE
Remove deprecated generation field

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -1152,8 +1152,7 @@ func ingressWithStatus(name string, generation int64, status v1alpha1.IngressSta
 			ResourceVersion: "v1",
 		},
 		Spec: v1alpha1.IngressSpec{
-			DeprecatedGeneration: generation,
-			Rules:                ingressRules,
+			Rules: ingressRules,
 		},
 		Status: status,
 	}


### PR DESCRIPTION
This patch removes DeprecatedGeneration from ingress test util.

Part of https://github.com/knative/networking/issues/195

/cc @ZhiminXiang @JRBANCEL @dprotaso