### PR TITLE
Add dummy.go to istio stable

### DIFF
--- a/third_party/istio-stable/dummy.go
+++ b/third_party/istio-stable/dummy.go
@@ -1,0 +1,15 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config exists to make the config directory importable.
+package config


### PR DESCRIPTION
This patch adds dummy.go in third_party/istio-stable.

After this patch, other repo like knative/docs can pull the directory and
use install-istio.sh and manifest.

/cc @ZhiminXiang @JRBANCEL @mattmoor @tcnghia 