### PR TITLE
Remove deprecated pkgTest.TLegacy

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"testing"
 	// Mysteriously required to support GCP auth (required by k8s libs).
 	// Apparently just importing it is enough. @_@ side effects @_@.
 	// https://github.com/kubernetes/client-go/issues/242
@@ -28,7 +29,7 @@ import (
 )
 
 // Setup creates client to run Knative Service requests
-func Setup(t pkgTest.TLegacy) *Clients {
+func Setup(t testing.TB) *Clients {
 	t.Helper()
 
 	cancel := logstream.Start(t)


### PR DESCRIPTION
The pkgTest.T/TLegacy interfaces have been deprecated, so remove their usage.

https://github.com/knative/networking/pull/236 is same PR for networking repo.

/cc @ZhiminXiang @markusthoemmes @tcnghia 