### PR TITLE
Add clusterDomain to values.global.proxy in kind yaml to replace it easily

### DIFF
--- a/third_party/istio-latest/istio-kind-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-mesh.yaml
@@ -19,6 +19,7 @@ spec:
     global:
       proxy:
         autoInject: enabled
+        clusterDomain: cluster.local
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens

--- a/third_party/istio-latest/istio-kind-no-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh.yaml
@@ -19,6 +19,7 @@ spec:
     global:
       proxy:
         autoInject: disabled
+        clusterDomain: cluster.local
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens

--- a/third_party/istio-stable/istio-kind-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-mesh.yaml
@@ -19,6 +19,7 @@ spec:
     global:
       proxy:
         autoInject: enabled
+        clusterDomain: cluster.local
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens

--- a/third_party/istio-stable/istio-kind-no-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh.yaml
@@ -19,6 +19,7 @@ spec:
     global:
       proxy:
         autoInject: disabled
+        clusterDomain: cluster.local
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens


### PR DESCRIPTION
When k8s cluster is changed the cluster.local domain, Istio (istio gateway
and sidecar) needs to change the domain by values.global.proxy.

This patch adds the value to replace it easily during KinD e2e.

Please see also https://github.com/knative/serving/issues/9750

/cc @mattmoor @tcnghia @ZhiminXiang @JRBANCEL 