### PR TITLE
Move knative-local-gateway service to istio-system.

### DIFF
--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -57,7 +57,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: knative-local-gateway
-  namespace: knative-serving
+  namespace: istio-system
   labels:
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -46,28 +46,31 @@ const (
 
 	// KnativeLocalGateway is the name of the local gateway (will be promoted)
 	KnativeLocalGateway = "knative-local-gateway"
+
+	// IstioIngressGateway is the name of the Istio ingress gateway
+	IstioIngressGateway = "istio-ingressgateway"
+
+	// IstioNamespace is the namespace containing Istio
+	IstioNamespace = "istio-system"
 )
 
 func defaultIngressGateways() []Gateway {
 	return []Gateway{{
-		Namespace: system.Namespace(),
-		Name:      KnativeIngressGateway,
-		ServiceURL: fmt.Sprintf("istio-ingressgateway.istio-system.svc.%s",
-			network.GetClusterDomainName()),
+		Namespace:  system.Namespace(),
+		Name:       KnativeIngressGateway,
+		ServiceURL: network.GetServiceHostname(IstioIngressGateway, IstioNamespace),
 	}}
 }
 
 func defaultLocalGateways() []Gateway {
 	return []Gateway{{
-		Namespace: system.Namespace(),
-		Name:      ClusterLocalGateway,
-		ServiceURL: fmt.Sprintf(ClusterLocalGateway+".istio-system.svc.%s",
-			network.GetClusterDomainName()),
+		Namespace:  system.Namespace(),
+		Name:       ClusterLocalGateway,
+		ServiceURL: network.GetServiceHostname(ClusterLocalGateway, IstioNamespace),
 	}, {
-		Namespace: system.Namespace(),
-		Name:      KnativeLocalGateway,
-		ServiceURL: fmt.Sprintf(KnativeLocalGateway+".knative-serving.svc.%s",
-			network.GetClusterDomainName()),
+		Namespace:  system.Namespace(),
+		Name:       KnativeLocalGateway,
+		ServiceURL: network.GetServiceHostname(KnativeLocalGateway, IstioNamespace),
 	}}
 }
 


### PR DESCRIPTION
There was a fatal in [my plan](https://github.com/knative-sandbox/net-istio/pull/237#issue-471304463) to collocate both Ingress and Local Gateways into the same Envoy Pods: k8s service selectors only work inside the same namespace (the Envoy Pods are in `istio-system`).

This moves the `knative-local-gateway` k8s service to `istio-system`, this is fine because this service is not being used yet (see phase #2 of the plan).

Also, this addresses @mattmoor [comment](https://github.com/knative-sandbox/net-istio/pull/237#discussion_r508943888) about using `network.GetServiceHostname`.
