### PR TITLE
Add missing labels to PeerAuthentication.

### DIFF
--- a/config/400-webhook-peer-authentication.yaml
+++ b/config/400-webhook-peer-authentication.yaml
@@ -5,6 +5,9 @@ kind: "PeerAuthentication"
 metadata:
   name: "webhook"
   namespace: "knative-serving"
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
 spec:
   selector:
     matchLabels:
@@ -17,6 +20,9 @@ kind: "PeerAuthentication"
 metadata:
   name: "istio-webhook"
   namespace: "knative-serving"
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Fixes #397.

/assign @houshengbo @tcnghia @ZhiminXiang 