### PR TITLE
Include commit ID in component YAML instead of release YAML.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -47,14 +47,15 @@ function build_release() {
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Knative net-istio - ${config}"
-    ko resolve --strict ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    echo "# Generated when HEAD was $(git rev-parse HEAD)" > ${yaml}
+    echo "#" >> ${yaml}
+    ko resolve --strict ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" >> ${yaml}
     all_yamls+=(${yaml})
   done
   # Assemble the release
   for yaml in "${!RELEASES[@]}"; do
     echo "Assembling Knative net-istio - ${yaml}"
-    echo "# Generated when HEAD was $(git rev-parse HEAD)" > ${yaml}
-    echo "#" >> ${yaml}
+    echo "" > ${yaml}
     for component in ${RELEASES[${yaml}]}; do
       echo "---" >> ${yaml}
       echo "# ${component}" >> ${yaml}


### PR DESCRIPTION
In https://github.com/knative-sandbox/net-istio/pull/288, the commit was only added to `release.yaml`.

The problem is that in `serving` we copy the component YAML(s) directly, not `release.yaml`.

This includes the commit ID in all component YAML (which also end up in `release.yaml` by concatenation.

/assign @tcnghia 