### PR TITLE
Use mesh mode when sidecar injection is enabled

### DIFF
--- a/third_party/istio-latest/install-istio.sh
+++ b/third_party/istio-latest/install-istio.sh
@@ -33,7 +33,7 @@ tar xzf ${ISTIO_TARBALL}
 # Enable mTLS STRICT in mesh mode
 if [[ $MESH -eq 1 ]]; then
   kubectl apply -f "$(dirname $0)/extra/global-mtls.yaml"
-  kubectl patch configmap/config-istio -n knative-serving --patch='{"data":{"local-gateway.mesh":"mesh"}}'
+  kubectl patch configmap/config-istio -n ${SYSTEM_NAMESPACE} --patch='{"data":{"local-gateway.mesh":"mesh"}}'
 fi
 
 # Clean up

--- a/third_party/istio-latest/install-istio.sh
+++ b/third_party/istio-latest/install-istio.sh
@@ -18,6 +18,7 @@
 ISTIO_VERSION=1.7.3
 ISTIO_TARBALL=istio-${ISTIO_VERSION}-linux-amd64.tar.gz
 DOWNLOAD_URL=https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/${ISTIO_TARBALL}
+SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-serving"}"
 
 wget --no-check-certificate $DOWNLOAD_URL
 if [ $? != 0 ]; then
@@ -32,6 +33,7 @@ tar xzf ${ISTIO_TARBALL}
 # Enable mTLS STRICT in mesh mode
 if [[ $MESH -eq 1 ]]; then
   kubectl apply -f "$(dirname $0)/extra/global-mtls.yaml"
+  kubectl patch configmap/config-istio -n knative-serving --patch='{"data":{"local-gateway.mesh":"mesh"}}'
 fi
 
 # Clean up

--- a/third_party/istio-stable/install-istio.sh
+++ b/third_party/istio-stable/install-istio.sh
@@ -33,7 +33,7 @@ tar xzf ${ISTIO_TARBALL}
 # Enable mTLS STRICT in mesh mode
 if [[ $MESH -eq 1 ]]; then
   kubectl apply -f "$(dirname $0)/extra/global-mtls.yaml"
-  kubectl patch configmap/config-istio -n knative-serving --patch='{"data":{"local-gateway.mesh":"mesh"}}'
+  kubectl patch configmap/config-istio -n ${SYSTEM_NAMESPACE} --patch='{"data":{"local-gateway.mesh":"mesh"}}'
 fi
 
 # Clean up

--- a/third_party/istio-stable/install-istio.sh
+++ b/third_party/istio-stable/install-istio.sh
@@ -18,6 +18,7 @@
 ISTIO_VERSION=1.7.1
 ISTIO_TARBALL=istio-${ISTIO_VERSION}-linux-amd64.tar.gz
 DOWNLOAD_URL=https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/${ISTIO_TARBALL}
+SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-serving"}"
 
 wget --no-check-certificate $DOWNLOAD_URL
 if [ $? != 0 ]; then
@@ -32,6 +33,7 @@ tar xzf ${ISTIO_TARBALL}
 # Enable mTLS STRICT in mesh mode
 if [[ $MESH -eq 1 ]]; then
   kubectl apply -f "$(dirname $0)/extra/global-mtls.yaml"
+  kubectl patch configmap/config-istio -n knative-serving --patch='{"data":{"local-gateway.mesh":"mesh"}}'
 fi
 
 # Clean up


### PR DESCRIPTION
This is a part of https://github.com/knative-sandbox/net-istio/issues/173.

By this patch, it enabled [`MeshOnly` API](https://github.com/knative/networking/blob/59e3a403ce6e06847bd610126cc2a66565fb9fd7/pkg/apis/networking/v1alpha1/ingress_types.go#L337-L339)
in ingress status.

/cc @ZhiminXiang @JRBANCEL @tcnghia 