### PR TITLE
Replace sample-controller with net-istio in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution guidelines
 
-So you want to hack on Knative `sample-controller`? Yay! Please refer to
+So you want to hack on Knative `net-istio`? Yay! Please refer to
 Knative's overall
 [contribution guidelines](https://www.knative.dev/contributing/) to find out how
 you can help.


### PR DESCRIPTION
This patch makes a tiny change to replace `sample-controller` with
`net-istio` in CONTRIBUTING.md.

/cc @ZhiminXiang @JRBANCEL @arturenault 