### PR TITLE
Remove extra brackets in table test

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -426,7 +426,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 		},
-	}, {}}
+	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{


### PR DESCRIPTION
This patch makes a super tiny change which removes extra brackets in table test.

/kind cleanup

**Release Note**

```release-note
NONE
```

/cc @ZhiminXiang @JRBANCEL @arturenault 
