### PR TITLE
Use ko 0.6.0 release

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -68,7 +68,11 @@ jobs:
     - name: Install Dependencies
       working-directory: ./
       run: |
-        GO111MODULE=on go get github.com/google/ko/cmd/ko@master
+        echo '::group:: install ko'
+        curl -L https://github.com/google/ko/releases/download/v0.6.0/ko_0.6.0_Linux_x86_64.tar.gz | tar xzf - ko
+        chmod +x ./ko
+        sudo mv ko /usr/local/bin
+        echo '::endgroup::'
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2


### PR DESCRIPTION
This patch changes to uses ko 0.6.0.

Currently all github actions are failing as https://github.com/knative-sandbox/net-istio/actions/runs/438456166.
This is same fix with https://github.com/knative-sandbox/net-contour/pull/390.

/kind cleanup

**Release Note**

```release-note
NONE
```
