### PR TITLE
Fix tiny logging/comment/naming bugs in virtualservice status test

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -396,7 +396,7 @@ func TestReconcile(t *testing.T) {
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("reconcile-virtualservice", "ingresses.networking.internal.knative.dev"),
 		},
-		PostConditions: []func(*testing.T, *TableRow){virtualServiceCalledTimes(1)},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(1)},
 		Key:            "test-ns/reconcile-virtualservice",
 	}, {
 		Name: "if ingress is already ready, we shouldn't call statusManager.IsReady",
@@ -408,7 +408,7 @@ func TestReconcile(t *testing.T) {
 			resources.MakeIngressVirtualService(context.Background(), insertProbe(ing("ingress-ready")),
 				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
 		},
-		PostConditions: []func(*testing.T, *TableRow){virtualServiceCalledTimes(0)},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
 	}, {
 		Name: "virtualService status ready should make ingress ready without probing",
 		Key:  "test-ns/ingress-virtualservice-ready",
@@ -469,7 +469,7 @@ func TestReconcile(t *testing.T) {
 				PublicLoadBalancer:  &v1alpha1.LoadBalancerStatus{Ingress: []v1alpha1.LoadBalancerIngressStatus{{DomainInternal: "test-ingressgateway.istio-system.svc.cluster.local"}}},
 			},
 				[]string{"ingresses.networking.internal.knative.dev"})}},
-		PostConditions: []func(*testing.T, *TableRow){virtualServiceCalledTimes(0)},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
 	}, {
 		Name: "virtualService status not ready should still avoid probing",
 		Key:  "test-ns/ingress-virtualservice-notready",
@@ -516,7 +516,7 @@ func TestReconcile(t *testing.T) {
 					},
 				}, 0),
 		},
-		PostConditions: []func(*testing.T, *TableRow){virtualServiceCalledTimes(0)},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
 	}, {
 		Name: "virtualService stale status should be the same as not ready",
 		Key:  "test-ns/ingress-virtualservice-stale",
@@ -563,7 +563,7 @@ func TestReconcile(t *testing.T) {
 					},
 				}, 1),
 		},
-		PostConditions: []func(*testing.T, *TableRow){virtualServiceCalledTimes(0)},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
@@ -1215,7 +1215,7 @@ func TestReconcile_DisableStatus(t *testing.T) {
 				PublicLoadBalancer:  &v1alpha1.LoadBalancerStatus{Ingress: []v1alpha1.LoadBalancerIngressStatus{{DomainInternal: "test-ingressgateway.istio-system.svc.cluster.local"}}},
 			},
 				[]string{"ingresses.networking.internal.knative.dev"})}},
-		PostConditions: []func(*testing.T, *TableRow){virtualServiceCalledTimes(0)},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
@@ -1761,13 +1761,13 @@ func makeGatewayMap(publicGateways []string, privateGateways []string) map[v1alp
 	}
 }
 
-func virtualServiceCalledTimes(n int) func(*testing.T, *TableRow) {
+func proberCalledTimes(n int) func(*testing.T, *TableRow) {
 	return func(t *testing.T, tr *TableRow) {
-		// ensure that prober gets invoked once
+		// ensure that prober gets invoked the required number of times
 		statusManager := tr.Ctx.Value(FakeStatusManagerKey).(*fakestatusmanager.FakeStatusManager)
 		callCount := statusManager.IsReadyCallCount(tr.Objects[0].(*v1alpha1.Ingress))
 		if callCount != n {
-			t.Errorf("statusManager.IsReady called %v times, wanted %v", callCount, 1)
+			t.Errorf("statusManager.IsReady called %v times, wanted %v", callCount, n)
 		}
 	}
 }


### PR DESCRIPTION
- Rename function from `virtualServiceCalledTimes` to `proberCalledTimes`, which is more accurate
- Fix a comment and an error log that both assumed n always == 1.