### PR TITLE
Release `istio.yaml` to simplify the installation.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -18,6 +18,7 @@
 # at https://github.com/knative/test-infra/tree/master/ci
 
 source $(dirname $0)/../vendor/knative.dev/hack/release.sh
+source $(dirname $0)/../third_party/download-istio.sh
 
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
@@ -63,6 +64,22 @@ function build_release() {
     done
     all_yamls+=(${yaml})
   done
+
+  # Build Istio YAML
+  ISTIO_STABLE="$(dirname $0)/../third_party/istio-stable"
+  ISTIO_VERSION=$(awk '/download_istio/ {print $2}' ${ISTIO_STABLE}/install-istio.sh)
+  ISTIO_YAML="istio.yaml"
+
+  echo "Downloading Istio"
+  download_istio $ISTIO_VERSION
+  trap cleanup_istio EXIT
+
+  echo "Assembling istio.yaml"
+  # `istiocl manifest generate` doesn't create the `istio-system` namespace
+  cat "${ISTIO_STABLE}/extra/istio-namespace.yaml" > ${ISTIO_YAML}
+  ${ISTIO_DIR}/bin/istioctl manifest generate -f $(realpath "${ISTIO_STABLE}/istio-ci-no-mesh.yaml") >> ${ISTIO_YAML}
+  all_yamls+=(${ISTIO_YAML})
+
   ARTIFACTS_TO_PUBLISH="${all_yamls[@]}"
 }
 

--- a/third_party/download-istio.sh
+++ b/third_party/download-istio.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function download_istio() {
+  # Find the right arch so we can download the correct istioctl version
+  case "${OSTYPE}" in
+    darwin*) ARCH=osx ;;
+    linux*) ARCH=linux-amd64 ;;
+    msys*) ARCH=win ;;
+    *) echo "** unknown OS '${OSTYPE}'" ; exit 1 ;;
+  esac
+
+  # Download and unpack Istio
+  ISTIO_VERSION=$1
+  ISTIO_TARBALL=istio-${ISTIO_VERSION}-${ARCH}.tar.gz
+  DOWNLOAD_URL=https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/${ISTIO_TARBALL}
+  SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-serving"}"
+
+  ISTIO_TMP=$(mktemp -d)
+  pushd $ISTIO_TMP
+  wget --no-check-certificate $DOWNLOAD_URL
+  if [ $? != 0 ]; then
+    echo "Failed to download Istio release: $DOWNLOAD_URL"
+    exit 1
+  fi
+  tar xzf ${ISTIO_TARBALL}
+  ISTIO_DIR="${ISTIO_TMP}/istio-${ISTIO_VERSION}"
+  echo "Istio was downloaded to ${ISTIO_TMP}"
+  popd
+}
+
+function cleanup_istio() {
+  echo "Deleting $ISTIO_TMP"
+  rm -rf $ISTIO_TMP
+}

--- a/third_party/istio-latest/install-istio.sh
+++ b/third_party/istio-latest/install-istio.sh
@@ -14,45 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Find the right arch so we can download the correct istioctl version
-case "${OSTYPE}" in
-  darwin*) ARCH=osx ;;
-  linux*) ARCH=linux-amd64 ;;
-  msys*) ARCH=win ;;
-  *) echo "** unknown OS '${OSTYPE}'" ; exit 1 ;;
-esac
+source $(dirname $0)/../download-istio.sh
 
-# Download and unpack Istio
-ISTIO_VERSION=1.8.1
-ISTIO_TARBALL=istio-${ISTIO_VERSION}-${ARCH}.tar.gz
-DOWNLOAD_URL=https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/${ISTIO_TARBALL}
-SYSTEM_NAMESPACE="${SYSTEM_NAMESPACE:-"knative-serving"}"
-
-wget --no-check-certificate $DOWNLOAD_URL
-if [ $? != 0 ]; then
-  echo "Failed to download Istio package"
-  exit 1
-fi
-tar xzf ${ISTIO_TARBALL}
+# Download Istio
+download_istio 1.8.1
+trap cleanup_istio EXIT
 
 # Install Istio with VirtualService status enabled
-./istio-${ISTIO_VERSION}/bin/istioctl install -f "$(dirname $0)/$1" -y --set values.pilot.env.PILOT_ENABLE_STATUS=true --set values.global.istiod.enableAnalysis=true
+${ISTIO_DIR}/bin/istioctl install -f "$(dirname $0)/$1" -y --set values.pilot.env.PILOT_ENABLE_STATUS=true --set values.global.istiod.enableAnalysis=true
 
 # Enable mTLS STRICT in mesh mode
 if [[ $MESH -eq 1 ]]; then
   kubectl apply -f "$(dirname $0)/extra/global-mtls.yaml"
 fi
-
-# Clean up
-rm -rf istio-${ISTIO_VERSION}
-rm ${ISTIO_TARBALL}
-
-## Add in the `istio-system` namespace to reduce number of commands.
-#patch istio-crds.yaml namespace.yaml.patch
-#patch istio-ci-mesh.yaml namespace.yaml.patch
-#patch istio-ci-no-mesh.yaml namespace.yaml.patch
-#patch istio-minimal.yaml namespace.yaml.patch
-#
-## Increase termination drain duration seconds.
-#patch -l istio-ci-mesh.yaml drain-seconds.yaml.patch
-

--- a/third_party/istio-stable/extra/istio-namespace.yaml
+++ b/third_party/istio-stable/extra/istio-namespace.yaml
@@ -1,12 +1,10 @@
-#!/usr/bin/env bash
-
-# Copyright 2019 The Knative Authors
+# Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,16 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source $(dirname $0)/../download-istio.sh
-
-# Download Istio
-download_istio 1.7.6
-trap cleanup_istio EXIT
-
-# Install Istio
-${ISTIO_DIR}/bin/istioctl install -f "$(dirname $0)/$1"
-
-# Enable mTLS STRICT in mesh mode
-if [[ $MESH -eq 1 ]]; then
-  kubectl apply -f "$(dirname $0)/extra/global-mtls.yaml"
-fi
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+---


### PR DESCRIPTION
Fixes  https://github.com/knative/docs/issues/2166.

`hack/release.sh` creates a file named `istio.yaml` so that users can do `kubectl apply -f istio.yaml`.

It is vastly inferior to using `istioctl`, but at least it is consistent and as easy as `kubectl apply -f contour.yaml`

Docs change: https://github.com/knative/docs/pull/3151

/assign @mattmoor @tcnghia 
/hold