### PR TITLE
Clean up some formatting and tidy loop

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -537,12 +537,12 @@ func (r *Reconciler) areVirtualServicesReady(ctx context.Context, vses []*v1alph
 		if err != nil {
 			// Log errors here, but don't return them.
 			// If an error occurred while checking VirtualService status, we'll just default to probing.
-			logger.Warnf("error occurred while checking virtual service status: %w", err)
+			logger.Warnf("error occurred while checking virtual service status: %v", err)
 			return false, false
 		}
 
 		if !hasStatus || !ready {
-			logger.Debugf("virtual service %q does not have status or has status and is not ready; skipping checks for others. hasStatus: %v, ready: %v", vs.Name, hasStatus, ready)
+			logger.Debugf("Virtual Service %q hasStatus=%v, ready=%v; skipping checks for others.", vs.Name, hasStatus, ready)
 			return hasStatus, ready
 		}
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -526,46 +526,37 @@ func isIngressPublic(ing *v1alpha1.Ingress) bool {
 }
 
 // areVirtualServicesReady checks if a virtual service has a status, and if so if it's ready.
-// the return values are (hasStatus, ready, error), where
+// The return values are (hasStatus, ready), where:
 //	hasStatus indicates whether the virtualService has a status field
 //	ready indicates whether it's been reconciled and able to receive requests
-//	error contains any errors that occurred during this
-func (r *Reconciler) areVirtualServicesReady(ctx context.Context, vses []*v1alpha3.VirtualService) (bool, bool) {
+func (r *Reconciler) areVirtualServicesReady(ctx context.Context, vses []*v1alpha3.VirtualService) (hasStatus bool, ready bool) {
 	logger := logging.FromContext(ctx)
 
-	var errs []error
-	hasStatus := true
-	ready := true
 	for _, vs := range vses {
-		_hasStatus, _ready, err := r.isVirtualServiceReady(ctx, vs)
+		hasStatus, ready, err := r.isVirtualServiceReady(ctx, vs)
 		if err != nil {
-			errs = append(errs, err)
+			// Log errors here, but don't return them.
+			// If an error occurred while checking VirtualService status, we'll just default to probing.
+			logger.Warnf("error occurred while checking virtual service status: %w", err)
+			return false, false
 		}
-
-		hasStatus = hasStatus && _hasStatus
-		ready = ready && _ready
 
 		if !hasStatus || !ready {
-			logger.Debugf("virtual service %q does not have status or not ready; skipping checks for others. hasStatus: %v, ready: %v", hasStatus, ready)
-			break
+			logger.Debugf("virtual service %q does not have status or has status and is not ready; skipping checks for others. hasStatus: %v, ready: %v", vs.Name, hasStatus, ready)
+			return hasStatus, ready
 		}
 	}
 
-	if len(errs) > 0 {
-		// Log errors here, but don't return them
-		// If errors occurred while probing VSes, we'll just default to probing
-		logger.Warnf("errors occurred while probing virtual services for status: %w",
-			errors.NewAggregate(errs))
-	}
-
-	return hasStatus, ready
+	// If either `hasStatus` or `ready` was ever false we would have already returned.
+	return true, true
 }
 
 // isVirtualServiceReady checks if a virtual service has a status, and if so if it's ready.
-// the return values are (hasStatus, ready), where
+// The return values are (hasStatus, ready, err), where:
 //	hasStatus indicates whether the virtualService has a status field
 //	ready indicates whether it's been reconciled and able to receive requests
-func (r *Reconciler) isVirtualServiceReady(ctx context.Context, vs *v1alpha3.VirtualService) (bool, bool, error) {
+//	err indicates an error occurred while looking up the status.
+func (r *Reconciler) isVirtualServiceReady(ctx context.Context, vs *v1alpha3.VirtualService) (hasStatus bool, ready bool, err error) {
 	logger := logging.FromContext(ctx)
 
 	if !config.FromContext(ctx).Istio.EnableVirtualServiceStatus {

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -537,7 +537,7 @@ func (r *Reconciler) areVirtualServicesReady(ctx context.Context, vses []*v1alph
 		if err != nil {
 			// Log errors here, but don't return them.
 			// If an error occurred while checking VirtualService status, we'll just default to probing.
-			logger.Warnf("error occurred while checking virtual service status: %v", err)
+			logger.Warnf("Error occurred while checking virtual service status: %v", err)
 			return false, false
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Came here to fix the Debugf, but figured I might as well tidy the function around it up a bit while I was touching it.

# Changes

 - 🧹 `Debugf()` was missing an argument (`vs.Name`) leading to messy log messages.
 - 🧹 Add names to return variables since otherwise they're easy to confuse here.
 - 🧹 Fix out-of-date method comment (remove err from one, add err to the other :)).
 - 🧹 Change comment and log message to say "checking VirtualService status" instead of "probing VS" since probing is exactly what we're checking the VS status to avoid having to do.
 - 🧹 We always exit after the first error (since `isVirtualServiceReady` returns "false, false, err" in that case), so remove the error appending and just log and return false straight away instead of storing the exactly-one error up.
 - 🧹 Drop the `hasStatus = hasStatus && _hasStatus` lines in favour of simply returning if either is false since (a) it's nice to avoid the underscore-prefixed vars (b) since we break/return immediately if either is ever false, they never really do anything (the previous values are _always_ true/true, or we would've stopped the loop already).
 
/kind cleanup

/assign @tcnghia  @ZhiminXiang 