### PR TITLE
Add placeholder.go under third_party

### DIFF
--- a/third_party/placeholder.go
+++ b/third_party/placeholder.go
@@ -1,0 +1,15 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config exists to make the config directory importable.
+package config


### PR DESCRIPTION
By the change c35f93d, `download-istio.sh` was located in `third_party`
directory.

knative.dev/docs needs to pull `download-istio.sh` so this patch adds
`placholder.go`

**Release Note**
```release-note
NONE
```
/cc @JRBANCEL @arturenault 