### PR TITLE
Clean up cluster-local-gateway in test code

### DIFF
--- a/pkg/reconciler/ingress/config/testdata/config-istio.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-istio.yaml
@@ -62,8 +62,12 @@ data:
     # {{local_gateway_namespace}} is optional; when it is omitted, the system
     # will search for the local gateway in the serving system namespace
     # `knative-serving`
-    local-gateway.knative-serving.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+    local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.istio-system.svc.cluster.local"
 
-    # To use only Istio service mesh and no cluster-local-gateway, replace
+    # To use only Istio service mesh and no knative-local-gateway, replace
     # all local-gateway.* entries by the following entry.
     local-gateway.mesh: "mesh"
+
+    # If true, knative will use the Istio VirtualService's status to determine
+    # endpoint readiness. Otherwise, probe as usual.
+    enable-virtualservice-status: "false"

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -234,10 +234,10 @@ func TestMakeVirtualServicesSpec_CorrectGateways(t *testing.T) {
 				},
 			},
 			gateways: map[v1alpha1.IngressVisibility]sets.String{
-				v1alpha1.IngressVisibilityClusterLocal: sets.NewString("cluster-local-gateway/knative-serving"),
+				v1alpha1.IngressVisibilityClusterLocal: sets.NewString("knative-local-gateway/knative-serving"),
 				v1alpha1.IngressVisibilityExternalIP:   sets.NewString("knative-ingress-gateway/knative-serving"),
 			},
-			expectedGateways: sets.NewString("cluster-local-gateway/knative-serving"),
+			expectedGateways: sets.NewString("knative-local-gateway/knative-serving"),
 		},
 		{
 			name: "public visibility",
@@ -253,7 +253,7 @@ func TestMakeVirtualServicesSpec_CorrectGateways(t *testing.T) {
 				},
 			},
 			gateways: map[v1alpha1.IngressVisibility]sets.String{
-				v1alpha1.IngressVisibilityClusterLocal: sets.NewString("cluster-local-gateway/knative-serving"),
+				v1alpha1.IngressVisibilityClusterLocal: sets.NewString("knative-local-gateway/knative-serving"),
 				v1alpha1.IngressVisibilityExternalIP:   sets.NewString("knative-ingress-gateway/knative-serving"),
 			},
 			expectedGateways: sets.NewString("knative-ingress-gateway/knative-serving"),
@@ -277,11 +277,11 @@ func TestMakeVirtualServicesSpec_CorrectGateways(t *testing.T) {
 				},
 			},
 			gateways: map[v1alpha1.IngressVisibility]sets.String{
-				v1alpha1.IngressVisibilityClusterLocal: sets.NewString("cluster-local-gateway/knative-serving"),
+				v1alpha1.IngressVisibilityClusterLocal: sets.NewString("knative-local-gateway/knative-serving"),
 				v1alpha1.IngressVisibilityExternalIP:   sets.NewString("knative-ingress-gateway/knative-serving"),
 			},
 			expectedGateways: sets.NewString("knative-ingress-gateway/knative-serving",
-				"cluster-local-gateway/knative-serving"),
+				"knative-local-gateway/knative-serving"),
 		},
 	}
 


### PR DESCRIPTION
This patch cleans up `cluster-local-gateway` in tests.

/kind cleanup

