### PR TITLE
Re-introduce behaviour of explicitly setting retries to 0

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -214,6 +214,7 @@ func makeVirtualServiceRoute(ctx context.Context, hosts sets.String, http *v1alp
 	}
 
 	route := &istiov1alpha3.HTTPRoute{
+		Retries: &istiov1alpha3.HTTPRetry{}, // Override default istio behaviour of retrying twice.
 		Match:   matches,
 		Route:   weights,
 		Rewrite: rewrite,

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -407,6 +407,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 	}
 	expected := []*istiov1alpha3.HTTPRoute{{
+		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Uri: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Regex{Regex: "^/pets/(.*?)?"},
@@ -515,6 +516,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 	}
 
 	expected := []*istiov1alpha3.HTTPRoute{{
+		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Uri: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Regex{Regex: "^/pets/(.*?)?"},
@@ -554,6 +556,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			},
 		},
 	}, {
+		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Uri: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Regex{Regex: "^/pets/(.*?)?"},
@@ -598,6 +601,7 @@ func TestMakeVirtualServiceRoute_RewriteHost(t *testing.T) {
 	})
 	route := makeVirtualServiceRoute(ctx, sets.NewString("a.vanity.url", "another.vanity.url"), ingressPath, makeGatewayMap([]string{"gateway-1"}, nil), v1alpha1.IngressVisibilityExternalIP)
 	expected := &istiov1alpha3.HTTPRoute{
+		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Gateways: []string{"gateway-1"},
 			Authority: &istiov1alpha3.StringMatch{
@@ -646,6 +650,7 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 	}
 	route := makeVirtualServiceRoute(context.Background(), sets.NewString("a.com", "b.org"), ingressPath, makeGatewayMap([]string{"gateway-1"}, nil), v1alpha1.IngressVisibilityExternalIP)
 	expected := &istiov1alpha3.HTTPRoute{
+		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Gateways: []string{"gateway-1"},
 			Authority: &istiov1alpha3.StringMatch{
@@ -705,6 +710,7 @@ func TestMakeVirtualServiceRoute_TwoTargets(t *testing.T) {
 	}
 	route := makeVirtualServiceRoute(context.Background(), sets.NewString("test.org"), ingressPath, makeGatewayMap([]string{"knative-testing/gateway-1"}, nil), v1alpha1.IngressVisibilityExternalIP)
 	expected := &istiov1alpha3.HTTPRoute{
+		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Gateways: []string{"knative-testing/gateway-1"},
 			Authority: &istiov1alpha3.StringMatch{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Re-introduces the behaviour of explicitly setting retries to zero, needed to override the Istio default of 2 retries. This was introduced in https://github.com/knative-sandbox/net-istio/pull/159 to fix https://github.com/knative/serving/issues/6549, but looks like it was accidentally dropped in https://github.com/knative-sandbox/net-istio/pull/263 when we bumped deps after removing the Retry field from KIngress.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Configures Istio not to retry requests. This was accidentally reverted in 0.18.
```

/assign @tcnghia @nak3 