### PR TITLE
Add retry test image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,6 @@ require (
 	k8s.io/apimachinery v0.19.7
 	k8s.io/client-go v0.19.7
 	knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf
-	knative.dev/networking v0.0.0-20210202173433-c069ad20a560
-	knative.dev/pkg v0.0.0-20210203171706-6045ed499615
+	knative.dev/networking v0.0.0-20210208003533-45b7ed13aeaa
+	knative.dev/pkg v0.0.0-20210204171111-887806985c09
 )

--- a/go.sum
+++ b/go.sum
@@ -1192,12 +1192,12 @@ knative.dev/hack v0.0.0-20210120165453-8d623a0af457 h1:jEBITgx/lQydGncM0uetpv/Zq
 knative.dev/hack v0.0.0-20210120165453-8d623a0af457/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf h1:u4cY4jr2LYvhoz/1HBWEPsMiLkm0HMdDTfmmw1RE8zE=
 knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/networking v0.0.0-20210202173433-c069ad20a560 h1:7k0pMfVwtCuRUnuzoK2BN8r2SgBki+HG8cjjQPPFz3U=
-knative.dev/networking v0.0.0-20210202173433-c069ad20a560/go.mod h1:LFCHSswO9cLifBJtuipVzw4M+nPdvkR1t82U6YJdhCA=
-knative.dev/pkg v0.0.0-20210130001831-ca02ef752ac6 h1:HIACRvhv/4U7vcFTAakfqYJIlENCSGtTrZOwz/q/A00=
-knative.dev/pkg v0.0.0-20210130001831-ca02ef752ac6/go.mod h1:X4NPrCo8NK3hbDVan9Vm7mf5io3ZoINakAdrpSXVB08=
+knative.dev/networking v0.0.0-20210208003533-45b7ed13aeaa h1:618cv8suiExQsAkFIgZNf6vfSqpGHI0y09aGokNWEzA=
+knative.dev/networking v0.0.0-20210208003533-45b7ed13aeaa/go.mod h1:Dl70Ul8xiCleoXGA2unSbfDvJN2oUfZXqVYsE6zl/rM=
 knative.dev/pkg v0.0.0-20210203171706-6045ed499615 h1:Ee0n+axzrQXWkJfGl91B5RRmB25R1plTfC7MDw3NxUU=
 knative.dev/pkg v0.0.0-20210203171706-6045ed499615/go.mod h1:X4NPrCo8NK3hbDVan9Vm7mf5io3ZoINakAdrpSXVB08=
+knative.dev/pkg v0.0.0-20210204171111-887806985c09 h1:GD7vfWNgJ9Yy6X9SxXJJj5+NSIg7/hOgNZCzQfHqIQI=
+knative.dev/pkg v0.0.0-20210204171111-887806985c09/go.mod h1:amlT9gE0VkgM+KDt2+i9Eo2y945AjCKh/My9FODy10w=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -28,6 +28,7 @@ import (
 	_ "knative.dev/networking/test/conformance/ingress"
 	_ "knative.dev/networking/test/test_images/grpc-ping"
 	_ "knative.dev/networking/test/test_images/httpproxy"
+	_ "knative.dev/networking/test/test_images/retry"
 	_ "knative.dev/networking/test/test_images/runtime"
 	_ "knative.dev/networking/test/test_images/timeout"
 	_ "knative.dev/networking/test/test_images/wsserver"

--- a/vendor/knative.dev/networking/test/conformance/ingress/retry.go
+++ b/vendor/knative.dev/networking/test/conformance/ingress/retry.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/networking/test"
+)
+
+// TestRetry verifies that the ingress does not retry failed requests.
+func TestRetry(t *testing.T) {
+	t.Parallel()
+	ctx, clients := context.Background(), test.Setup(t)
+	name, port, _ := CreateRetryService(ctx, t, clients)
+	domain := name + ".example.com"
+
+	// Create a simple Ingress over the Service.
+	_, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{domain},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	// First try - we expect this to fail, because we shouldn't retry
+	// automatically and the service only responds 200 on the _second_ access.
+	resp, err := client.Get("http://" + domain)
+	if err != nil {
+		t.Errorf("Error making GET request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("Got status %d, expected %d", resp.StatusCode, http.StatusServiceUnavailable)
+		DumpResponse(ctx, t, resp)
+	}
+
+	// Second try - this time we should succeed.
+	resp, err = client.Get("http://" + domain)
+	if err != nil {
+		t.Errorf("Error making GET request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Got not OK status, expected success: %d", resp.StatusCode)
+		DumpResponse(ctx, t, resp)
+	}
+}

--- a/vendor/knative.dev/networking/test/conformance/ingress/run.go
+++ b/vendor/knative.dev/networking/test/conformance/ingress/run.go
@@ -36,6 +36,7 @@ var stableTests = map[string]func(t *testing.T){
 	"dispatch/percentage":          TestPercentage,
 	"dispatch/path_and_percentage": TestPathAndPercentageSplit,
 	"dispatch/rule":                TestRule,
+	"retry":                        TestRetry,
 	"timeout":                      TestTimeout,
 	"tls":                          TestIngressTLS,
 	"update":                       TestUpdate,

--- a/vendor/knative.dev/networking/test/conformance/ingress/util.go
+++ b/vendor/knative.dev/networking/test/conformance/ingress/util.go
@@ -447,6 +447,76 @@ func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients,
 	return name, port, createPodAndService(ctx, t, clients, pod, svc)
 }
 
+// CreateRetryService creates a service that will return a 503 on first access, and then 200 after that.
+func CreateRetryService(ctx context.Context, t *testing.T, clients *test.Clients) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            "foo",
+				Image:           pkgTest.ImagePath("retry"),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Ports: []corev1.ContainerPort{{
+					Name:          networking.ServicePortNameH2C,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						TCPSocket: &corev1.TCPSocketAction{
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(ctx, t, clients, pod, svc)
+}
+
 // createService is a helper for creating the service resource.
 func createService(ctx context.Context, t *testing.T, clients *test.Clients, svc *corev1.Service) context.CancelFunc {
 	t.Helper()

--- a/vendor/knative.dev/networking/test/test_images/retry/main.go
+++ b/vendor/knative.dev/networking/test/test_images/retry/main.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	network "knative.dev/networking/pkg"
+	"knative.dev/networking/test"
+)
+
+var retries = 0
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	if retries == 0 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	fmt.Fprintf(w, "Retry %d", retries)
+	retries++
+}
+
+func main() {
+	h := network.NewProbeHandler(http.HandlerFunc(handler))
+	test.ListenAndServeGracefully(":"+os.Getenv("PORT"), h.ServeHTTP)
+}

--- a/vendor/knative.dev/networking/test/test_images/retry/service.yaml
+++ b/vendor/knative.dev/networking/test/test_images/retry/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: retry-test-image
+  name: timeout-test-image
   namespace: default
 spec:
   template:
     spec:
       containers:
-      - image: ko://knative.dev/networking/test/test_images/timeout
+      - image: ko://knative.dev/networking/test/test_images/retry

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -818,7 +818,7 @@ k8s.io/utils/trace
 # knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf
 ## explicit
 knative.dev/hack
-# knative.dev/networking v0.0.0-20210202173433-c069ad20a560
+# knative.dev/networking v0.0.0-20210208003533-45b7ed13aeaa
 ## explicit
 knative.dev/networking/pkg
 knative.dev/networking/pkg/apis/networking
@@ -852,12 +852,13 @@ knative.dev/networking/test/defaultsystem
 knative.dev/networking/test/test_images/grpc-ping
 knative.dev/networking/test/test_images/grpc-ping/proto
 knative.dev/networking/test/test_images/httpproxy
+knative.dev/networking/test/test_images/retry
 knative.dev/networking/test/test_images/runtime
 knative.dev/networking/test/test_images/runtime/handlers
 knative.dev/networking/test/test_images/timeout
 knative.dev/networking/test/test_images/wsserver
 knative.dev/networking/test/types
-# knative.dev/pkg v0.0.0-20210203171706-6045ed499615
+# knative.dev/pkg v0.0.0-20210204171111-887806985c09
 ## explicit
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck


### PR DESCRIPTION
This patch adds retry test image which was added by
https://github.com/knative/networking/commit/45b7ed13aeaa6276d6399cec0e3354c8acd8dbd0.

/kind cleanup

**Release Note**

```release-note
NONE
```
