### PR TITLE
Properly implement Splits support in RewriteHost

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -135,7 +135,7 @@ func makeVirtualServiceSpec(ctx context.Context, ing *v1alpha1.Ingress, gateways
 			p := rule.HTTP.Paths[i]
 			hosts := hosts.Intersection(sets.NewString(rule.Hosts...))
 			if hosts.Len() != 0 {
-				http := makeVirtualServiceRoute(ctx, hosts, &p, gateways, rule.Visibility)
+				http := makeVirtualServiceRoute(hosts, &p, gateways, rule.Visibility)
 				// Add all the Gateways that exist inside the http.match section of
 				// the VirtualService.
 				// This ensures that we are only using the Gateways that actually appear
@@ -151,7 +151,7 @@ func makeVirtualServiceSpec(ctx context.Context, ing *v1alpha1.Ingress, gateways
 	return &spec
 }
 
-func makeVirtualServiceRoute(ctx context.Context, hosts sets.String, http *v1alpha1.HTTPIngressPath, gateways map[v1alpha1.IngressVisibility]sets.String, visibility v1alpha1.IngressVisibility) *istiov1alpha3.HTTPRoute {
+func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, gateways map[v1alpha1.IngressVisibility]sets.String, visibility v1alpha1.IngressVisibility) *istiov1alpha3.HTTPRoute {
 	matches := []*istiov1alpha3.HTTPMatchRequest{}
 	clusterDomainName := network.GetClusterDomainName()
 	for _, host := range hosts.List() {
@@ -201,16 +201,6 @@ func makeVirtualServiceRoute(ctx context.Context, hosts sets.String, http *v1alp
 		rewrite = &istiov1alpha3.HTTPRewrite{
 			Authority: http.RewriteHost,
 		}
-
-		weights = []*istiov1alpha3.HTTPRouteDestination{{
-			Weight: 100,
-			Destination: &istiov1alpha3.Destination{
-				Host: privateGatewayServiceURLFromContext(ctx),
-				Port: &istiov1alpha3.PortSelector{
-					Number: GatewayHTTPPort,
-				},
-			},
-		}}
 	}
 
 	route := &istiov1alpha3.HTTPRoute{

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -286,7 +286,7 @@ func TestMakeVirtualServicesSpec_CorrectGateways(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			vs := makeVirtualServiceSpec(context.Background(), tc.ingress, tc.gateways, ingress.ExpandedHosts(getHosts(tc.ingress)))
+			vs := makeVirtualServiceSpec(tc.ingress, tc.gateways, ingress.ExpandedHosts(getHosts(tc.ingress)))
 			actualGateways := sets.NewString(vs.Gateways...)
 			if !actualGateways.Equal(tc.expectedGateways) {
 				t.Fatalf("Got gateways %v, expected %v", actualGateways.List(), tc.expectedGateways.List())


### PR DESCRIPTION
We added support for specifying (actually, a requirement to supply!) splits to the API (https://github.com/knative/networking/pull/107), but the istio implementation was still actually hard-coding the gateway as the backend for RewriteHost rules, and ignoring the splits. 

This changes that so we properly respect the passed splits like the other ingresses do. (In practice none of our current use cases work differently either way so this didn't matter, but that could change and it's good to be consistent).


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Ingresses with RewriteHost specified now properly respect passed Splits
```

/assign @nak3 @tcnghia 
