### PR TITLE
Add namespace to stable's extra folder to fix nightly builds

### DIFF
--- a/third_party/istio-stable/extra/istio-namespace.yaml
+++ b/third_party/istio-stable/extra/istio-namespace.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+---


### PR DESCRIPTION
The release script depends on this file being there in order to correctly assemble the release YAML. It was dropped (accidentally?) in #515.