### PR TITLE
Add CODEOWNERS file for approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owners are Networking WG leads and TOC
+* @knative-sandbox/technical-oversight-committee
+* @knative-sandbox/knative-release-leads
+* @knative-sandbox/networking-wg-leads
+# Last match takes precedence for reviews
+* @knative-sandbox/net-istio-approvers
+
+# hack and test are owned by productivity
+/hack/* @knative-sandbox/productivity-wg-leads
+/test/* @knative-sandbox/productivity-wg-leads


### PR DESCRIPTION
Needs: knative/community#479 for the net-istio-approvers to work.