### PR TITLE
Use prefix matching for KIngress rule paths

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -223,7 +223,7 @@ func keepLocalHostnames(hosts sets.String) sets.String {
 	return retained
 }
 
-func makeMatch(host string, pathRegExp string, headers map[string]v1alpha1.HeaderMatch, gateways sets.String) *istiov1alpha3.HTTPMatchRequest {
+func makeMatch(host, path string, headers map[string]v1alpha1.HeaderMatch, gateways sets.String) *istiov1alpha3.HTTPMatchRequest {
 	match := &istiov1alpha3.HTTPMatchRequest{
 		Gateways: gateways.List(),
 		Authority: &istiov1alpha3.StringMatch{
@@ -231,11 +231,11 @@ func makeMatch(host string, pathRegExp string, headers map[string]v1alpha1.Heade
 			MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: hostPrefix(host)},
 		},
 	}
-	// Empty pathRegExp is considered match all path. We only need to
-	// consider pathRegExp when it's non-empty.
-	if pathRegExp != "" {
+	// Empty path is considered match all path. We only need to consider path
+	// when it's non-empty.
+	if path != "" {
 		match.Uri = &istiov1alpha3.StringMatch{
-			MatchType: &istiov1alpha3.StringMatch_Regex{Regex: pathRegExp},
+			MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: path},
 		}
 	}
 

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -365,7 +365,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 				},
 				HTTP: &v1alpha1.HTTPIngressRuleValue{
 					Paths: []v1alpha1.HTTPIngressPath{{
-						Path: "^/pets/(.*?)?",
+						Path: "/pets/",
 						Splits: []v1alpha1.IngressBackendSplit{{
 							IngressBackend: v1alpha1.IngressBackend{
 								ServiceNamespace: "test-ns",
@@ -388,7 +388,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 				},
 				HTTP: &v1alpha1.HTTPIngressRuleValue{
 					Paths: []v1alpha1.HTTPIngressPath{{
-						Path: "^/pets/(.*?)?",
+						Path: "/pets/",
 						Splits: []v1alpha1.IngressBackendSplit{{
 							IngressBackend: v1alpha1.IngressBackend{
 								ServiceNamespace: "test-ns",
@@ -409,7 +409,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Uri: &istiov1alpha3.StringMatch{
-				MatchType: &istiov1alpha3.StringMatch_Regex{Regex: "^/pets/(.*?)?"},
+				MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: "/pets/"},
 			},
 			Authority: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: `test-route.test-ns`},
@@ -472,7 +472,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 				},
 				HTTP: &v1alpha1.HTTPIngressRuleValue{
 					Paths: []v1alpha1.HTTPIngressPath{{
-						Path: "^/pets/(.*?)?",
+						Path: "/pets/",
 						Splits: []v1alpha1.IngressBackendSplit{{
 							IngressBackend: v1alpha1.IngressBackend{
 								ServiceNamespace: "test-ns",
@@ -496,7 +496,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 				},
 				HTTP: &v1alpha1.HTTPIngressRuleValue{
 					Paths: []v1alpha1.HTTPIngressPath{{
-						Path: "^/pets/(.*?)?",
+						Path: "/pets/",
 						Splits: []v1alpha1.IngressBackendSplit{{
 							IngressBackend: v1alpha1.IngressBackend{
 								ServiceNamespace: "test-ns",
@@ -518,7 +518,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Uri: &istiov1alpha3.StringMatch{
-				MatchType: &istiov1alpha3.StringMatch_Regex{Regex: "^/pets/(.*?)?"},
+				MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: "/pets/"},
 			},
 			Authority: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: `domain.com`},
@@ -526,7 +526,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 			Gateways: []string{"gateway.public"},
 		}, {
 			Uri: &istiov1alpha3.StringMatch{
-				MatchType: &istiov1alpha3.StringMatch_Regex{Regex: "^/pets/(.*?)?"},
+				MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: "/pets/"},
 			},
 			Authority: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: `test-route.test-ns`},
@@ -558,7 +558,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		Retries: &istiov1alpha3.HTTPRetry{},
 		Match: []*istiov1alpha3.HTTPMatchRequest{{
 			Uri: &istiov1alpha3.StringMatch{
-				MatchType: &istiov1alpha3.StringMatch_Regex{Regex: "^/pets/(.*?)?"},
+				MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: "/pets/"},
 			},
 			Authority: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Prefix{Prefix: `v1.domain.com`},


### PR DESCRIPTION
:broom: This change updates the matching mode for rule paths to use prefix matching instead of regular expression matching. The regular expression mode was never correctly implemented by Knative when generating rules, and most other networking layers only support prefix matching anyway.

See the discussion here for more context: https://github.com/knative/networking/pull/364

/kind cleanup