### PR TITLE
Add a feature flag to guard pod addressability additions

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -71,3 +71,7 @@ data:
     # If true, knative will use the Istio VirtualService's status to determine
     # endpoint readiness. Otherwise, probe as usual.
     enable-virtualservice-status: "false"
+
+    # If true, knative will add additional information to all deployed applications to
+    # make their pods directly accessible via their IPs even if mesh is enabled.
+    enable-mesh-pod-addressability: "false"

--- a/pkg/reconciler/ingress/config/istio_test.go
+++ b/pkg/reconciler/ingress/config/istio_test.go
@@ -308,3 +308,58 @@ func TestVSStatusEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestPodAddressabilityEnabled(t *testing.T) {
+	vsStatusTests := []struct {
+		name        string
+		wantErr     bool
+		wantEnabled interface{}
+		config      *corev1.ConfigMap
+	}{{
+		name:        "enabled",
+		wantEnabled: true,
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				EnableMeshPodAddressabilityKey: "true",
+			},
+		},
+	}, {
+		name:        "disabled default",
+		wantEnabled: false,
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+		},
+	}, {
+		name:    "invalid",
+		wantErr: true,
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				EnableMeshPodAddressabilityKey: "not_a_bool",
+			},
+		},
+	},
+	}
+	for _, tt := range vsStatusTests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := NewIstioFromConfigMap(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewIstioFromConfigMap() error = %v, WantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil && config.EnableMeshPodAddressability != tt.wantEnabled {
+				t.Errorf("Want %v, but got %v", tt.wantEnabled, config.EnableMeshPodAddressability)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/ingress/config/istio_test.go
+++ b/pkg/reconciler/ingress/config/istio_test.go
@@ -310,7 +310,7 @@ func TestVSStatusEnabled(t *testing.T) {
 }
 
 func TestPodAddressabilityEnabled(t *testing.T) {
-	vsStatusTests := []struct {
+	tests := []struct {
 		name        string
 		wantErr     bool
 		wantEnabled interface{}
@@ -350,7 +350,7 @@ func TestPodAddressabilityEnabled(t *testing.T) {
 		},
 	},
 	}
-	for _, tt := range vsStatusTests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config, err := NewIstioFromConfigMap(tt.config)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Ref https://github.com/knative/serving/issues/10751

Adds a feature flag to allow us to control whether or not the pod addessability stuff is enabled or not, to allow for focused testing and hardening before enabling by default.

/assign @julz @arturenault 
