### PR TITLE
Add configuration for graceful shutdown to ingressgateways

### DIFF
--- a/third_party/istio-head/istio-ci-mesh.yaml
+++ b/third_party/istio-head/istio-ci-mesh.yaml
@@ -49,6 +49,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-head/istio-ci-no-mesh.yaml
+++ b/third_party/istio-head/istio-ci-no-mesh.yaml
@@ -42,6 +42,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-head/istio-kind-mesh.yaml
+++ b/third_party/istio-head/istio-kind-mesh.yaml
@@ -51,6 +51,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-head/istio-kind-no-mesh.yaml
+++ b/third_party/istio-head/istio-kind-no-mesh.yaml
@@ -44,6 +44,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-head/istio-minimal.yaml
+++ b/third_party/istio-head/istio-minimal.yaml
@@ -32,3 +32,7 @@ spec:
     ingressGateways:
       - name: istio-ingressgateway
         enabled: true
+        k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'

--- a/third_party/istio-latest/istio-ci-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-mesh.yaml
@@ -49,6 +49,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-latest/istio-ci-no-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh.yaml
@@ -42,6 +42,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-latest/istio-kind-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-mesh.yaml
@@ -51,6 +51,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-latest/istio-kind-no-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh.yaml
@@ -44,6 +44,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-latest/istio-minimal.yaml
+++ b/third_party/istio-latest/istio-minimal.yaml
@@ -32,3 +32,7 @@ spec:
     ingressGateways:
       - name: istio-ingressgateway
         enabled: true
+        k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'

--- a/third_party/istio-stable/istio-ci-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-mesh.yaml
@@ -49,6 +49,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-stable/istio-ci-no-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh.yaml
@@ -42,6 +42,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-stable/istio-kind-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-mesh.yaml
@@ -51,6 +51,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-stable/istio-kind-no-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh.yaml
@@ -44,6 +44,9 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-stable/istio-minimal.yaml
+++ b/third_party/istio-stable/istio-minimal.yaml
@@ -32,3 +32,7 @@ spec:
     ingressGateways:
       - name: istio-ingressgateway
         enabled: true
+        k8s:
+          env:
+            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
+              value: '20'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

We seem to be seeing flaky connections in the Serving E2E test suite due to ingressgateways shutting down during tests. We're configuring this value for mesh pods as well, so maybe this'll help (the default value is 5s).

/hold

For verification in Serving first.