### PR TITLE
Add an accessor for DestinationRule objects

### DIFF
--- a/pkg/reconciler/accessor/istio/destinationrule.go
+++ b/pkg/reconciler/accessor/istio/destinationrule.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/accessor/istio/destinationrule.go
+++ b/pkg/reconciler/accessor/istio/destinationrule.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package istio
+
+import (
+	"context"
+	"fmt"
+
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	istioclientset "knative.dev/net-istio/pkg/client/istio/clientset/versioned"
+	istiolisters "knative.dev/net-istio/pkg/client/istio/listers/networking/v1alpha3"
+	kaccessor "knative.dev/net-istio/pkg/reconciler/accessor"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
+)
+
+// DestinationRuleAccessor is an interface for accessing DestinationRule.
+type DestinationRuleAccessor interface {
+	GetIstioClient() istioclientset.Interface
+	GetDestinationRuleLister() istiolisters.DestinationRuleLister
+}
+
+func destionationRuleIsDifferent(current, desired *v1alpha3.DestinationRule) bool {
+	return !equality.Semantic.DeepEqual(current.Spec, desired.Spec) ||
+		!equality.Semantic.DeepEqual(current.Labels, desired.Labels) ||
+		!equality.Semantic.DeepEqual(current.Annotations, desired.Annotations)
+}
+
+// ReconcileDestinationRule reconciles DestinationRule to the desired status.
+func ReconcileDestinationRule(ctx context.Context, owner kmeta.Accessor, desired *v1alpha3.DestinationRule,
+	drAccessor DestinationRuleAccessor) (*v1alpha3.DestinationRule, error) {
+
+	recorder := controller.GetEventRecorder(ctx)
+	if recorder == nil {
+		return nil, fmt.Errorf("recorder for reconciling DestinationRule %s/%s is not created", desired.Namespace, desired.Name)
+	}
+	ns := desired.Namespace
+	name := desired.Name
+	dr, err := drAccessor.GetDestinationRuleLister().DestinationRules(ns).Get(name)
+	if apierrs.IsNotFound(err) {
+		dr, err = drAccessor.GetIstioClient().NetworkingV1alpha3().DestinationRules(ns).Create(ctx, desired, metav1.CreateOptions{})
+		if err != nil {
+			recorder.Eventf(owner, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create DestinationRule %s/%s: %v", ns, name, err)
+			return nil, fmt.Errorf("failed to create DestinationRule: %w", err)
+		}
+		recorder.Eventf(owner, corev1.EventTypeNormal, "Created", "Created DestinationRule %q", desired.Name)
+	} else if err != nil {
+		return nil, err
+	} else if !metav1.IsControlledBy(dr, owner) {
+		// Return an error with NotControlledBy information.
+		return nil, kaccessor.NewAccessorError(
+			fmt.Errorf("owner: %s with Type %T does not own DestinationRule: %q", owner.GetName(), owner, name),
+			kaccessor.NotOwnResource)
+	} else if destionationRuleIsDifferent(dr, desired) {
+		// Don't modify the informers copy
+		existing := dr.DeepCopy()
+		existing.Spec = desired.Spec
+		existing.Labels = desired.Labels
+		existing.Annotations = desired.Annotations
+		dr, err = drAccessor.GetIstioClient().NetworkingV1alpha3().DestinationRules(ns).Update(ctx, existing, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to update DestinationRule: %w", err)
+		}
+		recorder.Eventf(owner, corev1.EventTypeNormal, "Updated", "Updated DestinationRule %s/%s", ns, name)
+	}
+	return dr, nil
+}

--- a/pkg/reconciler/accessor/istio/destinationrule_test.go
+++ b/pkg/reconciler/accessor/istio/destinationrule_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package istio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	istiov1alpha3 "istio.io/api/networking/v1alpha3"
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	istioclientset "knative.dev/net-istio/pkg/client/istio/clientset/versioned"
+	fakeistioclient "knative.dev/net-istio/pkg/client/istio/injection/client/fake"
+	fakedrinformer "knative.dev/net-istio/pkg/client/istio/injection/informers/networking/v1alpha3/destinationrule/fake"
+	istiolisters "knative.dev/net-istio/pkg/client/istio/listers/networking/v1alpha3"
+
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+var (
+	originDR = &v1alpha3.DestinationRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "dr",
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: istiov1alpha3.DestinationRule{
+			Host: "origin.example.com",
+		},
+	}
+
+	desiredDR = &v1alpha3.DestinationRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "dr",
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: istiov1alpha3.DestinationRule{
+			Host: "desired.example.com",
+		},
+	}
+)
+
+type FakeDestinatioRuleAccessor struct {
+	client   istioclientset.Interface
+	drLister istiolisters.DestinationRuleLister
+}
+
+func (f *FakeDestinatioRuleAccessor) GetIstioClient() istioclientset.Interface {
+	return f.client
+}
+
+func (f *FakeDestinatioRuleAccessor) GetDestinationRuleLister() istiolisters.DestinationRuleLister {
+	return f.drLister
+}
+
+func TestReconcileDestinationRule_Create(t *testing.T) {
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+
+	istio := fakeistioclient.Get(ctx)
+	drInformer := fakedrinformer.Get(ctx)
+
+	waitInformers, err := RunAndSyncInformers(ctx, informers...)
+	if err != nil {
+		t.Fatal("Failed to start informers")
+	}
+	defer func() {
+		cancel()
+		waitInformers()
+	}()
+
+	accessor := &FakeDestinatioRuleAccessor{
+		client:   istio,
+		drLister: drInformer.Lister(),
+	}
+
+	h := NewHooks()
+	h.OnCreate(&istio.Fake, "destinationrules", func(obj runtime.Object) HookResult {
+		got := obj.(*v1alpha3.DestinationRule)
+		if diff := cmp.Diff(got, desiredDR); diff != "" {
+			t.Log("Unexpected DestinationRule (-want, +got):", diff)
+			return HookIncomplete
+		}
+		return HookComplete
+	})
+
+	ReconcileDestinationRule(ctx, ownerObj, desiredDR, accessor)
+
+	if err := h.WaitForHooks(3 * time.Second); err != nil {
+		t.Error("Failed to Reconcile DestinationRule:", err)
+	}
+}
+
+func TestReconcileDestinationRule_Update(t *testing.T) {
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+
+	istio := fakeistioclient.Get(ctx)
+	drInformer := fakedrinformer.Get(ctx)
+
+	waitInformers, err := RunAndSyncInformers(ctx, informers...)
+	if err != nil {
+		t.Fatal("Failed to start informers")
+	}
+	defer func() {
+		cancel()
+		waitInformers()
+	}()
+
+	accessor := &FakeDestinatioRuleAccessor{
+		client:   istio,
+		drLister: drInformer.Lister(),
+	}
+
+	istio.NetworkingV1alpha3().DestinationRules(origin.Namespace).Create(ctx, originDR, metav1.CreateOptions{})
+	drInformer.Informer().GetIndexer().Add(originDR)
+
+	h := NewHooks()
+	h.OnUpdate(&istio.Fake, "destinationrules", func(obj runtime.Object) HookResult {
+		got := obj.(*v1alpha3.DestinationRule)
+		if diff := cmp.Diff(got, desiredDR); diff != "" {
+			t.Log("Unexpected DestinationRule (-want, +got):", diff)
+			return HookIncomplete
+		}
+		return HookComplete
+	})
+
+	ReconcileDestinationRule(ctx, ownerObj, desiredDR, accessor)
+	if err := h.WaitForHooks(3 * time.Second); err != nil {
+		t.Error("Failed to Reconcile DestinationRule:", err)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Ref knative/serving#10751

Adds a helper to reconcile destionationrules the same way we have an accessor for virtualservices. The code is mostly copy and pasted and then the respective resource names have been replaced.

/assign @vagababov @ZhiminXiang 