### PR TITLE
Implement the SKS reconciler for pod addressability

### DIFF
--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -27,7 +27,6 @@ import (
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	sksinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 	sksreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -46,7 +45,6 @@ func NewController(
 	destinationRuleInformer := destinationruleinformer.Get(ctx)
 
 	c := &reconciler{
-		kubeclient:            kubeclient.Get(ctx),
 		istioclient:           istioclient.Get(ctx),
 		virtualServiceLister:  virtualServiceInformer.Lister(),
 		destinationRuleLister: destinationRuleInformer.Lister(),

--- a/pkg/reconciler/serverlessservice/resources/destinationrule.go
+++ b/pkg/reconciler/serverlessservice/resources/destinationrule.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
@@ -38,7 +36,7 @@ const (
 func MakeDestinationRule(sks *v1alpha1.ServerlessService) *v1alpha3.DestinationRule {
 	ns := sks.Namespace
 	name := kmeta.ChildName(sks.Name, "-private")
-	host := fmt.Sprintf("%s.%s.svc.%s", name, ns, pkgnetwork.GetClusterDomainName())
+	host := pkgnetwork.GetServiceHostname(name, ns)
 
 	return &v1alpha3.DestinationRule{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/serverlessservice/resources/destinationrule.go
+++ b/pkg/reconciler/serverlessservice/resources/destinationrule.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	istiov1alpha3 "istio.io/api/networking/v1alpha3"
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/kmeta"
+	pkgnetwork "knative.dev/pkg/network"
+)
+
+const (
+	subsetNormal = "normal"
+	subsetDirect = "direct"
+)
+
+// MakeDestinationRule creates a DestinationRule that defines a "normal" and a "direct"
+// loadbalancer for the service in question, to allow for pod addressability, even in mesh.
+func MakeDestinationRule(sks *v1alpha1.ServerlessService) *v1alpha3.DestinationRule {
+	ns := sks.Namespace
+	name := kmeta.ChildName(sks.Name, "-private")
+	host := fmt.Sprintf("%s.%s.svc.%s", name, ns, pkgnetwork.GetClusterDomainName())
+
+	return &v1alpha3.DestinationRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       ns,
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(sks)},
+		},
+		Spec: istiov1alpha3.DestinationRule{
+			Host: host,
+			Subsets: []*istiov1alpha3.Subset{{
+				Name: subsetNormal,
+				TrafficPolicy: &istiov1alpha3.TrafficPolicy{
+					LoadBalancer: &istiov1alpha3.LoadBalancerSettings{
+						LbPolicy: &istiov1alpha3.LoadBalancerSettings_Simple{
+							Simple: istiov1alpha3.LoadBalancerSettings_LEAST_CONN,
+						},
+					},
+				},
+			}, {
+				Name: subsetDirect,
+				TrafficPolicy: &istiov1alpha3.TrafficPolicy{
+					LoadBalancer: &istiov1alpha3.LoadBalancerSettings{
+						LbPolicy: &istiov1alpha3.LoadBalancerSettings_Simple{
+							Simple: istiov1alpha3.LoadBalancerSettings_PASSTHROUGH,
+						},
+					},
+				},
+			}},
+		},
+	}
+}

--- a/pkg/reconciler/serverlessservice/resources/virtualservice.go
+++ b/pkg/reconciler/serverlessservice/resources/virtualservice.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
@@ -34,7 +32,7 @@ import (
 func MakeVirtualService(sks *v1alpha1.ServerlessService) *v1alpha3.VirtualService {
 	ns := sks.Namespace
 	name := kmeta.ChildName(sks.Name, "-private")
-	host := fmt.Sprintf("%s.%s.svc.%s", name, ns, pkgnetwork.GetClusterDomainName())
+	host := pkgnetwork.GetServiceHostname(name, ns)
 
 	return &v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/serverlessservice/resources/virtualservice.go
+++ b/pkg/reconciler/serverlessservice/resources/virtualservice.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	istiov1alpha3 "istio.io/api/networking/v1alpha3"
+	"istio.io/client-go/pkg/apis/networking/v1alpha3"
+	network "knative.dev/networking/pkg"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/kmeta"
+	pkgnetwork "knative.dev/pkg/network"
+)
+
+// MakeVirtualService creates a placeholder virtual service to allow direct
+// pod addressability, even for mesh cases.
+func MakeVirtualService(sks *v1alpha1.ServerlessService) *v1alpha3.VirtualService {
+	ns := sks.Namespace
+	name := kmeta.ChildName(sks.Name, "-private")
+	host := fmt.Sprintf("%s.%s.svc.%s", name, ns, pkgnetwork.GetClusterDomainName())
+
+	return &v1alpha3.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       sks.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(sks)},
+		},
+		Spec: istiov1alpha3.VirtualService{
+			Hosts: []string{host},
+			Http: []*istiov1alpha3.HTTPRoute{{
+				Match: []*istiov1alpha3.HTTPMatchRequest{{
+					Headers: map[string]*istiov1alpha3.StringMatch{
+						network.PassthroughLoadbalancingHeaderName: {
+							MatchType: &istiov1alpha3.StringMatch_Exact{
+								Exact: "true",
+							},
+						},
+					},
+				}},
+				Route: []*istiov1alpha3.HTTPRouteDestination{{
+					Destination: &istiov1alpha3.Destination{
+						Host:   host,
+						Subset: subsetDirect,
+					},
+				}},
+			}, {
+				Route: []*istiov1alpha3.HTTPRouteDestination{{
+					Destination: &istiov1alpha3.Destination{
+						Host:   host,
+						Subset: subsetNormal,
+					},
+				}},
+			}},
+		},
+	}
+}

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -191,7 +191,6 @@ func TestReconcile(t *testing.T) {
 		return sksreconciler.NewReconciler(ctx, logging.FromContext(ctx), fakenetworkingclient.Get(ctx),
 			listers.GetServerlessServiceLister(), controller.GetEventRecorder(ctx), r, controller.Options{
 				ConfigStore: &testConfigStore{
-					// Enable reconciling gateway.
 					config: &config.Config{
 						Istio: &config.Istio{
 							EnableMeshPodAddressability: true,

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+istributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serverlessservice
+
+import (
+	"context"
+	"testing"
+
+	// Inject our fakes
+	istioclient "knative.dev/net-istio/pkg/client/istio/injection/client"
+	fakenetworkingclient "knative.dev/networking/pkg/client/injection/client/fake"
+
+	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/net-istio/pkg/reconciler/ingress/config"
+	"knative.dev/net-istio/pkg/reconciler/serverlessservice/resources"
+	network "knative.dev/networking/pkg"
+	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	sksreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+
+	. "knative.dev/net-istio/pkg/reconciler/testing"
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+func sks(name string) *netv1alpha1.ServerlessService {
+	sks := &netv1alpha1.ServerlessService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testing",
+			Name:      name,
+		},
+	}
+
+	// Status has no effect on this reconciler, so just default it.
+	sks.Status.InitializeConditions()
+
+	return sks
+}
+
+func vs(name string) *istiov1alpha3.VirtualService {
+	return resources.MakeVirtualService(sks(name))
+}
+
+func dr(name string) *istiov1alpha3.DestinationRule {
+	return resources.MakeDestinationRule(sks(name))
+}
+
+func TestReconcile(t *testing.T) {
+	table := TableTest{{
+		Name: "bad workqueue key",
+		Key:  "too/many/parts",
+	}, {
+		Name: "key not found",
+		Key:  "foo/not-found",
+	}, {
+		Name: "stable state",
+		Key:  "testing/test",
+		Objects: []runtime.Object{
+			sks("test"),
+			vs("test"),
+			dr("test"),
+		},
+	}, {
+		Name: "create both",
+		Key:  "testing/test",
+		Objects: []runtime.Object{
+			sks("test"),
+		},
+		WantCreates: []runtime.Object{
+			vs("test"),
+			dr("test"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "test-private"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created DestinationRule %q", "test-private"),
+		},
+	}, {
+		Name: "create only VirtualService",
+		Key:  "testing/test",
+		Objects: []runtime.Object{
+			sks("test"),
+			dr("test"),
+		},
+		WantCreates: []runtime.Object{
+			vs("test"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "test-private"),
+		},
+	}, {
+		Name: "create only DestinationRule",
+		Key:  "testing/test",
+		Objects: []runtime.Object{
+			sks("test"),
+			vs("test"),
+		},
+		WantCreates: []runtime.Object{
+			dr("test"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created DestinationRule %q", "test-private"),
+		},
+	}, {
+		Name: "fix both",
+		Key:  "testing/test",
+		Objects: []runtime.Object{
+			sks("test"),
+			func() *istiov1alpha3.VirtualService {
+				virtualService := vs("test")
+				virtualService.Spec.Hosts = []string{"foo"}
+				return virtualService
+			}(),
+			func() *istiov1alpha3.DestinationRule {
+				destinationRule := dr("test")
+				destinationRule.Spec.Host = "foo"
+				return destinationRule
+			}(),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: vs("test"),
+		}, {
+			Object: dr("test"),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated VirtualService %s", "testing/test-private"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated DestinationRule %s", "testing/test-private"),
+		},
+	}, {
+		Name:    "failure for VirtualService",
+		Key:     "testing/test",
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("create", "virtualservices"),
+		},
+		Objects: []runtime.Object{
+			sks("test"),
+			dr("test"),
+		},
+		WantCreates: []runtime.Object{
+			vs("test"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create VirtualService %s: inducing failure for create virtualservices", "testing/test-private"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to reconcile VirtualService: failed to create VirtualService: inducing failure for create virtualservices"),
+		},
+	}, {
+		Name:    "failure for DestinationRule",
+		Key:     "testing/test",
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("create", "destinationrules"),
+		},
+		Objects: []runtime.Object{
+			sks("test"),
+			vs("test"),
+		},
+		WantCreates: []runtime.Object{
+			dr("test"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create DestinationRule %s: inducing failure for create destinationrules", "testing/test-private"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to reconcile DestinationRule: failed to create DestinationRule: inducing failure for create destinationrules"),
+		},
+	}}
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		r := &reconciler{
+			istioclient:           istioclient.Get(ctx),
+			virtualServiceLister:  listers.GetVirtualServiceLister(),
+			destinationRuleLister: listers.GetDestinationRuleLister(),
+		}
+
+		return sksreconciler.NewReconciler(ctx, logging.FromContext(ctx), fakenetworkingclient.Get(ctx),
+			listers.GetServerlessServiceLister(), controller.GetEventRecorder(ctx), r, controller.Options{
+				ConfigStore: &testConfigStore{
+					// Enable reconciling gateway.
+					config: &config.Config{
+						Istio: &config.Istio{
+							EnableMeshPodAddressability: true,
+						},
+						Network: &network.Config{},
+					},
+				},
+			})
+	}))
+}
+
+type testConfigStore struct {
+	config *config.Config
+}
+
+func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
+	return config.ToContext(ctx, t.config)
+}

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -88,6 +88,11 @@ func (l *Listers) GetIngressLister() networkinglisters.IngressLister {
 	return networkinglisters.NewIngressLister(l.IndexerFor(&networking.Ingress{}))
 }
 
+// GetServerlessServiceLister get lister for ServerlessService resource.
+func (l *Listers) GetServerlessServiceLister() networkinglisters.ServerlessServiceLister {
+	return networkinglisters.NewServerlessServiceLister(l.IndexerFor(&networking.ServerlessService{}))
+}
+
 // GetGatewayLister get lister for Gateway resource.
 func (l *Listers) GetGatewayLister() istiolisters.GatewayLister {
 	return istiolisters.NewGatewayLister(l.IndexerFor(&istiov1alpha3.Gateway{}))
@@ -96,6 +101,11 @@ func (l *Listers) GetGatewayLister() istiolisters.GatewayLister {
 // GetVirtualServiceLister get lister for istio VirtualService resource.
 func (l *Listers) GetVirtualServiceLister() istiolisters.VirtualServiceLister {
 	return istiolisters.NewVirtualServiceLister(l.IndexerFor(&istiov1alpha3.VirtualService{}))
+}
+
+// GetDestinationRuleLister get lister for istio DestinationRule resource.
+func (l *Listers) GetDestinationRuleLister() istiolisters.DestinationRuleLister {
+	return istiolisters.NewDestinationRuleLister(l.IndexerFor(&istiov1alpha3.DestinationRule{}))
 }
 
 // GetK8sServiceLister get lister for K8s Service resource.


### PR DESCRIPTION
Ref knative/serving#10751

This implements the actual reconciler and its resources. Note that the reconciler still isn't hooked into main so it won't be running after merging this.