### PR TITLE
fix name conflict in image registry and add webhook port env

### DIFF
--- a/config/webhook-deployment.yaml
+++ b/config/webhook-deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       serviceAccountName: controller
       containers:
-      - name: webhook
+      - name: istio-webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
         image: ko://knative.dev/net-istio/cmd/webhook
@@ -64,7 +64,8 @@ spec:
           value: knative.dev/net-istio
         - name: WEBHOOK_NAME
           value: istio-webhook
-
+        - name: WEBHOOK_PORT
+          value: '8443'
         securityContext:
           allowPrivilegeEscalation: false
 


### PR DESCRIPTION

# Changes

- bug: Fix bug https://github.com/knative/operator/issues/519

/kind bug


Fixes https://github.com/knative/operator/issues/519

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

```release-note
fix installation issue using operator when images are pulled from private registry
```


