### PR TITLE
Disable autoscaling for ingress gateways

### DIFF
--- a/third_party/istio-head/istio-ci-mesh.yaml
+++ b/third_party/istio-head/istio-ci-mesh.yaml
@@ -30,8 +30,8 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 2
-        autoscaleMax: 5
+        autoscaleMin: 3
+        autoscaleMax: 3
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
 

--- a/third_party/istio-head/istio-ci-no-mesh.yaml
+++ b/third_party/istio-head/istio-ci-no-mesh.yaml
@@ -30,8 +30,8 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 2
-        autoscaleMax: 5
+        autoscaleMin: 3
+        autoscaleMax: 3
 
   addonComponents:
     pilot:

--- a/third_party/istio-head/istio-kind-mesh.yaml
+++ b/third_party/istio-head/istio-kind-mesh.yaml
@@ -32,7 +32,7 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleMin: 1
-        autoscaleMax: 3
+        autoscaleMax: 1
         type: NodePort
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true

--- a/third_party/istio-head/istio-kind-no-mesh.yaml
+++ b/third_party/istio-head/istio-kind-no-mesh.yaml
@@ -32,7 +32,7 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleMin: 1
-        autoscaleMax: 3
+        autoscaleMax: 1
         type: NodePort
 
   addonComponents:

--- a/third_party/istio-latest/istio-ci-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-mesh.yaml
@@ -30,8 +30,8 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 2
-        autoscaleMax: 5
+        autoscaleMin: 3
+        autoscaleMax: 3
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
 

--- a/third_party/istio-latest/istio-ci-no-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh.yaml
@@ -30,8 +30,8 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 2
-        autoscaleMax: 5
+        autoscaleMin: 3
+        autoscaleMax: 3
 
   addonComponents:
     pilot:

--- a/third_party/istio-latest/istio-kind-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-mesh.yaml
@@ -32,7 +32,7 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleMin: 1
-        autoscaleMax: 3
+        autoscaleMax: 1
         type: NodePort
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true

--- a/third_party/istio-latest/istio-kind-no-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh.yaml
@@ -32,7 +32,7 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleMin: 1
-        autoscaleMax: 3
+        autoscaleMax: 1
         type: NodePort
 
   addonComponents:

--- a/third_party/istio-stable/istio-ci-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-mesh.yaml
@@ -30,8 +30,8 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 2
-        autoscaleMax: 5
+        autoscaleMin: 3
+        autoscaleMax: 3
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
 

--- a/third_party/istio-stable/istio-ci-no-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh.yaml
@@ -30,8 +30,8 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 2
-        autoscaleMax: 5
+        autoscaleMin: 3
+        autoscaleMax: 3
 
   addonComponents:
     pilot:

--- a/third_party/istio-stable/istio-kind-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-mesh.yaml
@@ -32,7 +32,7 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleMin: 1
-        autoscaleMax: 3
+        autoscaleMax: 1
         type: NodePort
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true

--- a/third_party/istio-stable/istio-kind-no-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh.yaml
@@ -32,7 +32,7 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleMin: 1
-        autoscaleMax: 3
+        autoscaleMax: 1
         type: NodePort
 
   addonComponents:


### PR DESCRIPTION
HPA scaling down ingress gateways causes flakes in CI, which reflect legitimate problems production users might experience.

We tried [bumping the drain time to 20 seconds](https://github.com/knative-sandbox/net-istio/pull/553) but we still see flakes since one test requires at least 35 seconds. In reality this feels like a real problem unless we set the shutdown time to 5 minutes+ (the default max revision timeout), and even then scaling down an ingress gateway will kill long running requests (e.g. websockets).

Bumping the drain time again, to 40 seconds, would also fix the flakes, but would be covering up a real problem that would hit users in production. Disabling autoscaling for the ingress gateway seems like the safer out-of-the-box default for now.

<!-- Thanks for sending a pull request! -->

# Changes

- :bug: Disable autoscaling of ingress gateways, since this interacts badly with long running requests

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Disable autoscaling of ingress gateways out of the box, since this interacts badly with long running requests. Operators that wish to enable autoscaling of ingress gateways should make sure to set the drain timeouts high enough for their longest running requests.
```

/assign @markusthoemmes @ZhiminXiang @nak3 
