### PR TITLE
Properly disable HPA for ingressgateways

### DIFF
--- a/third_party/istio-head/istio-ci-mesh.yaml
+++ b/third_party/istio-head/istio-ci-mesh.yaml
@@ -30,8 +30,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 3
-        autoscaleMax: 3
+        autoscaleEnabled: false
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
 
@@ -49,6 +48,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 3
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-head/istio-ci-no-mesh.yaml
+++ b/third_party/istio-head/istio-ci-no-mesh.yaml
@@ -30,8 +30,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 3
-        autoscaleMax: 3
+        autoscaleEnabled: false
 
   addonComponents:
     pilot:
@@ -42,6 +41,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 3
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-head/istio-kind-mesh.yaml
+++ b/third_party/istio-head/istio-kind-mesh.yaml
@@ -31,8 +31,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 1
-        autoscaleMax: 1
+        autoscaleEnabled: false
         type: NodePort
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
@@ -51,6 +50,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 1
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-head/istio-kind-no-mesh.yaml
+++ b/third_party/istio-head/istio-kind-no-mesh.yaml
@@ -31,8 +31,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 1
-        autoscaleMax: 1
+        autoscaleEnabled: false
         type: NodePort
 
   addonComponents:
@@ -44,6 +43,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 1
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-latest/istio-ci-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-mesh.yaml
@@ -30,8 +30,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 3
-        autoscaleMax: 3
+        autoscaleEnabled: false
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
 
@@ -49,6 +48,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 3
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-latest/istio-ci-no-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh.yaml
@@ -30,8 +30,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 3
-        autoscaleMax: 3
+        autoscaleEnabled: false
 
   addonComponents:
     pilot:
@@ -42,6 +41,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 3
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-latest/istio-kind-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-mesh.yaml
@@ -31,8 +31,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 1
-        autoscaleMax: 1
+        autoscaleEnabled: false
         type: NodePort
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
@@ -51,6 +50,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 1
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-latest/istio-kind-no-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh.yaml
@@ -31,8 +31,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 1
-        autoscaleMax: 1
+        autoscaleEnabled: false
         type: NodePort
 
   addonComponents:
@@ -44,6 +43,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 1
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-stable/istio-ci-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-mesh.yaml
@@ -30,8 +30,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 3
-        autoscaleMax: 3
+        autoscaleEnabled: false
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
 
@@ -49,6 +48,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 3
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-stable/istio-ci-no-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh.yaml
@@ -30,8 +30,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 3
-        autoscaleMax: 3
+        autoscaleEnabled: false
 
   addonComponents:
     pilot:
@@ -42,6 +41,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 3
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-stable/istio-kind-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-mesh.yaml
@@ -31,8 +31,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 1
-        autoscaleMax: 1
+        autoscaleEnabled: false
         type: NodePort
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
@@ -51,6 +50,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 1
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'

--- a/third_party/istio-stable/istio-kind-no-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh.yaml
@@ -31,8 +31,7 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 1
-        autoscaleMax: 1
+        autoscaleEnabled: false
         type: NodePort
 
   addonComponents:
@@ -44,6 +43,7 @@ spec:
       - name: istio-ingressgateway
         enabled: true
         k8s:
+          replicaCount: 1
           env:
             - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
               value: '20'


### PR DESCRIPTION
As per title, this fixes https://github.com/knative-sandbox/net-istio/pull/570 which sadly had no effect on autoscaling. This now explicitly disables the HPAs and manually sets the desired replicaCount.

/assign @julz @nak3 