### PR TITLE
Use SKS' PrivateServiceName field rather than generate it

### DIFF
--- a/pkg/reconciler/serverlessservice/resources/destinationrule.go
+++ b/pkg/reconciler/serverlessservice/resources/destinationrule.go
@@ -35,7 +35,7 @@ const (
 // loadbalancer for the service in question, to allow for pod addressability, even in mesh.
 func MakeDestinationRule(sks *v1alpha1.ServerlessService) *v1alpha3.DestinationRule {
 	ns := sks.Namespace
-	name := kmeta.ChildName(sks.Name, "-private")
+	name := sks.Status.PrivateServiceName
 	host := pkgnetwork.GetServiceHostname(name, ns)
 
 	return &v1alpha3.DestinationRule{

--- a/pkg/reconciler/serverlessservice/resources/virtualservice.go
+++ b/pkg/reconciler/serverlessservice/resources/virtualservice.go
@@ -31,7 +31,7 @@ import (
 // pod addressability, even for mesh cases.
 func MakeVirtualService(sks *v1alpha1.ServerlessService) *v1alpha3.VirtualService {
 	ns := sks.Namespace
-	name := kmeta.ChildName(sks.Name, "-private")
+	name := sks.Status.PrivateServiceName
 	host := pkgnetwork.GetServiceHostname(name, ns)
 
 	return &v1alpha3.VirtualService{

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -53,6 +53,11 @@ func (r *reconciler) ReconcileKind(ctx context.Context, sks *netv1alpha1.Serverl
 		return nil
 	}
 
+	if sks.Status.PrivateServiceName == "" {
+		// No private service yet, nothing to do here.
+		return nil
+	}
+
 	vs := resources.MakeVirtualService(sks)
 	if _, err := istioaccessor.ReconcileVirtualService(ctx, sks, vs, r); err != nil {
 		return fmt.Errorf("failed to reconcile VirtualService: %w", err)

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -48,6 +48,9 @@ func sks(name string) *netv1alpha1.ServerlessService {
 			Namespace: "testing",
 			Name:      name,
 		},
+		Status: netv1alpha1.ServerlessServiceStatus{
+			PrivateServiceName: name + "-foo",
+		},
 	}
 
 	// Status has no effect on this reconciler, so just default it.
@@ -90,8 +93,8 @@ func TestReconcile(t *testing.T) {
 			dr("test"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "test-private"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created DestinationRule %q", "test-private"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "test-foo"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created DestinationRule %q", "test-foo"),
 		},
 	}, {
 		Name: "create only VirtualService",
@@ -104,7 +107,7 @@ func TestReconcile(t *testing.T) {
 			vs("test"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "test-private"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "test-foo"),
 		},
 	}, {
 		Name: "create only DestinationRule",
@@ -117,7 +120,7 @@ func TestReconcile(t *testing.T) {
 			dr("test"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created DestinationRule %q", "test-private"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created DestinationRule %q", "test-foo"),
 		},
 	}, {
 		Name: "fix both",
@@ -141,8 +144,8 @@ func TestReconcile(t *testing.T) {
 			Object: dr("test"),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Updated", "Updated VirtualService %s", "testing/test-private"),
-			Eventf(corev1.EventTypeNormal, "Updated", "Updated DestinationRule %s", "testing/test-private"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated VirtualService %s", "testing/test-foo"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated DestinationRule %s", "testing/test-foo"),
 		},
 	}, {
 		Name:    "failure for VirtualService",
@@ -159,7 +162,7 @@ func TestReconcile(t *testing.T) {
 			vs("test"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create VirtualService %s: inducing failure for create virtualservices", "testing/test-private"),
+			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create VirtualService %s: inducing failure for create virtualservices", "testing/test-foo"),
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to reconcile VirtualService: failed to create VirtualService: inducing failure for create virtualservices"),
 		},
 	}, {
@@ -177,7 +180,7 @@ func TestReconcile(t *testing.T) {
 			dr("test"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create DestinationRule %s: inducing failure for create destinationrules", "testing/test-private"),
+			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create DestinationRule %s: inducing failure for create destinationrules", "testing/test-foo"),
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to reconcile DestinationRule: failed to create DestinationRule: inducing failure for create destinationrules"),
 		},
 	}}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

As per title, this makes the SKS reconciler here a little more robust and relies on the correct contracts.

/assign @nak3 