### PR TITLE
Drop --strict flag on ko

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -49,7 +49,7 @@ function build_release() {
     echo "Building Knative net-istio - ${config}"
     echo "# Generated when HEAD was $(git rev-parse HEAD)" > ${yaml}
     echo "#" >> ${yaml}
-    ko resolve --strict --platform=all ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" >> ${yaml}
+    ko resolve --platform=all ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" >> ${yaml}
     all_yamls+=(${yaml})
   done
   # Assemble the release


### PR DESCRIPTION
As per title. Since https://github.com/google/ko/commit/6586a72f8a458b6b2139fd8b97d4412afab91f03 this has been the default and we recently updated `ko` in CI.

/assign @nak3