### PR TITLE
[istio-stable] renable global mTLS when in mesh mode

### DIFF
--- a/third_party/istio-stable/extra/istio-mesh.yaml
+++ b/third_party/istio-stable/extra/istio-mesh.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: STRICT

--- a/third_party/istio-stable/generate-manifests.sh
+++ b/third_party/istio-stable/generate-manifests.sh
@@ -17,18 +17,3 @@
 source "$(dirname $0)/../library.sh"
 
 generate "1.9.1" "$(dirname $0)"
-
-# Temporarily disable mTLS STRICT in mesh mode
-# see: this (https://github.com/knative-sandbox/net-istio/issues/503)
-# To reenable this create the file extra/istio-mesh.yaml with the following
-#
-# ---
-# apiVersion: "security.istio.io/v1beta1"
-# kind: "PeerAuthentication"
-# metadata:
-#   name: "default"
-#   namespace: "istio-system"
-# spec:
-#   mtls:
-#     mode: STRICT
-

--- a/third_party/istio-stable/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-ci-mesh/istio.yaml
@@ -5783,3 +5783,12 @@ spec:
                   code:
                     local:
                       inline_string: envoy.wasm.stats
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: STRICT

--- a/third_party/istio-stable/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-kind-mesh/istio.yaml
@@ -5783,3 +5783,12 @@ spec:
                   code:
                     local:
                       inline_string: envoy.wasm.stats
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: STRICT


### PR DESCRIPTION
mTLS was disabled in https://github.com/knative-sandbox/net-istio/pull/517  But this is causing confusion downstream in `serving` since we didn't realize the change had occurred.

Going forward I think we should have consistency with our `istio-*` yamls and perform any specific overrides in `serving` 

Related: https://github.com/knative-sandbox/net-istio/issues/503