### PR TITLE
Add PILOT_ENABLED_SERVICE_APIS to manifest

### DIFF
--- a/third_party/istio-head/istio-ci-mesh.yaml
+++ b/third_party/istio-head/istio-ci-mesh.yaml
@@ -24,6 +24,8 @@ spec:
       autoscaleMax: 10
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-head/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-head/istio-ci-mesh/istio.yaml
@@ -6225,7 +6225,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0",
+        "tag": "1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -6417,7 +6417,7 @@ data:
             {{- end }}
             restartPolicy: Always
           {{ end -}}
-          {{- if eq .Values.global.proxy.enableCoreDump true }}
+          {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           - name: enable-core-dump
             args:
             - -c
@@ -6460,12 +6460,6 @@ data:
             - sidecar
             - --domain
             - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-            - --serviceCluster
-            {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-            - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-            {{ else -}}
-            - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-            {{ end -}}
             - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel }}
             - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel }}
             - --log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}
@@ -6525,14 +6519,6 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: CANONICAL_SERVICE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-name']
-            - name: CANONICAL_REVISION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-revision']
             - name: PROXY_CONFIG
               value: |
                      {{ protoToJSON .ProxyConfig }}
@@ -6559,11 +6545,6 @@ data:
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -6623,7 +6604,7 @@ data:
                 drop:
                 - ALL
               privileged: {{ .Values.global.proxy.privileged }}
-              readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
+              readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
               runAsGroup: 1337
               fsGroup: 1337
               {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
@@ -6888,11 +6869,6 @@ data:
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -7155,7 +7131,7 @@ spec:
               value: "20"
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: gcr.io/istio-testing/proxyv2:1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0
+          image: gcr.io/istio-testing/proxyv2:1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7331,6 +7307,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
@@ -7345,9 +7323,7 @@ spec:
               value: "true"
             - name: CLUSTER_ID
               value: Kubernetes
-            - name: EXTERNAL_ISTIOD
-              value: "false"
-          image: gcr.io/istio-testing/pilot:1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0
+          image: gcr.io/istio-testing/pilot:1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58
           name: discovery
           ports:
             - containerPort: 8080
@@ -7551,6 +7527,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7586,6 +7563,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7623,6 +7601,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7656,6 +7635,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:

--- a/third_party/istio-head/istio-ci-no-mesh.yaml
+++ b/third_party/istio-head/istio-ci-no-mesh.yaml
@@ -21,6 +21,8 @@ spec:
       autoscaleMax: 10
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-head/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-head/istio-ci-no-mesh/istio.yaml
@@ -6224,7 +6224,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0",
+        "tag": "1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -6416,7 +6416,7 @@ data:
             {{- end }}
             restartPolicy: Always
           {{ end -}}
-          {{- if eq .Values.global.proxy.enableCoreDump true }}
+          {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           - name: enable-core-dump
             args:
             - -c
@@ -6459,12 +6459,6 @@ data:
             - sidecar
             - --domain
             - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-            - --serviceCluster
-            {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-            - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-            {{ else -}}
-            - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-            {{ end -}}
             - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel }}
             - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel }}
             - --log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}
@@ -6524,14 +6518,6 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: CANONICAL_SERVICE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-name']
-            - name: CANONICAL_REVISION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-revision']
             - name: PROXY_CONFIG
               value: |
                      {{ protoToJSON .ProxyConfig }}
@@ -6558,11 +6544,6 @@ data:
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -6622,7 +6603,7 @@ data:
                 drop:
                 - ALL
               privileged: {{ .Values.global.proxy.privileged }}
-              readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
+              readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
               runAsGroup: 1337
               fsGroup: 1337
               {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
@@ -6887,11 +6868,6 @@ data:
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -7154,7 +7130,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: gcr.io/istio-testing/proxyv2:1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0
+          image: gcr.io/istio-testing/proxyv2:1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7330,6 +7306,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
@@ -7344,9 +7322,7 @@ spec:
               value: "true"
             - name: CLUSTER_ID
               value: Kubernetes
-            - name: EXTERNAL_ISTIOD
-              value: "false"
-          image: gcr.io/istio-testing/pilot:1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0
+          image: gcr.io/istio-testing/pilot:1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58
           name: discovery
           ports:
             - containerPort: 8080
@@ -7550,6 +7526,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7585,6 +7562,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7622,6 +7600,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7655,6 +7634,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:

--- a/third_party/istio-head/istio-kind-mesh.yaml
+++ b/third_party/istio-head/istio-kind-mesh.yaml
@@ -25,6 +25,8 @@ spec:
       autoscaleMax: 3
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-head/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-head/istio-kind-mesh/istio.yaml
@@ -6225,7 +6225,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0",
+        "tag": "1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -6417,7 +6417,7 @@ data:
             {{- end }}
             restartPolicy: Always
           {{ end -}}
-          {{- if eq .Values.global.proxy.enableCoreDump true }}
+          {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           - name: enable-core-dump
             args:
             - -c
@@ -6460,12 +6460,6 @@ data:
             - sidecar
             - --domain
             - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-            - --serviceCluster
-            {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-            - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-            {{ else -}}
-            - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-            {{ end -}}
             - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel }}
             - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel }}
             - --log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}
@@ -6525,14 +6519,6 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: CANONICAL_SERVICE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-name']
-            - name: CANONICAL_REVISION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-revision']
             - name: PROXY_CONFIG
               value: |
                      {{ protoToJSON .ProxyConfig }}
@@ -6559,11 +6545,6 @@ data:
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -6623,7 +6604,7 @@ data:
                 drop:
                 - ALL
               privileged: {{ .Values.global.proxy.privileged }}
-              readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
+              readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
               runAsGroup: 1337
               fsGroup: 1337
               {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
@@ -6888,11 +6869,6 @@ data:
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -7155,7 +7131,7 @@ spec:
               value: "20"
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: gcr.io/istio-testing/proxyv2:1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0
+          image: gcr.io/istio-testing/proxyv2:1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7331,6 +7307,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
@@ -7345,9 +7323,7 @@ spec:
               value: "true"
             - name: CLUSTER_ID
               value: Kubernetes
-            - name: EXTERNAL_ISTIOD
-              value: "false"
-          image: gcr.io/istio-testing/pilot:1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0
+          image: gcr.io/istio-testing/pilot:1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58
           name: discovery
           ports:
             - containerPort: 8080
@@ -7551,6 +7527,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7586,6 +7563,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7623,6 +7601,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7656,6 +7635,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:

--- a/third_party/istio-head/istio-kind-no-mesh.yaml
+++ b/third_party/istio-head/istio-kind-no-mesh.yaml
@@ -24,6 +24,8 @@ spec:
       autoscaleMax: 3
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-head/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-head/istio-kind-no-mesh/istio.yaml
@@ -6224,7 +6224,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0",
+        "tag": "1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -6416,7 +6416,7 @@ data:
             {{- end }}
             restartPolicy: Always
           {{ end -}}
-          {{- if eq .Values.global.proxy.enableCoreDump true }}
+          {{- if eq (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
           - name: enable-core-dump
             args:
             - -c
@@ -6459,12 +6459,6 @@ data:
             - sidecar
             - --domain
             - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-            - --serviceCluster
-            {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-            - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-            {{ else -}}
-            - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-            {{ end -}}
             - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel }}
             - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel }}
             - --log_output_level={{ annotation .ObjectMeta `sidecar.istio.io/agentLogLevel` .Values.global.logging.level }}
@@ -6524,14 +6518,6 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: CANONICAL_SERVICE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-name']
-            - name: CANONICAL_REVISION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['service.istio.io/canonical-revision']
             - name: PROXY_CONFIG
               value: |
                      {{ protoToJSON .ProxyConfig }}
@@ -6558,11 +6544,6 @@ data:
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -6622,7 +6603,7 @@ data:
                 drop:
                 - ALL
               privileged: {{ .Values.global.proxy.privileged }}
-              readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
+              readOnlyRootFilesystem: {{ ne (annotation .ObjectMeta `sidecar.istio.io/enableCoreDump` .Values.global.proxy.enableCoreDump) "true" }}
               runAsGroup: 1337
               fsGroup: 1337
               {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
@@ -6887,11 +6868,6 @@ data:
             - name: ISTIO_META_NETWORK
               value: "{{ .Values.global.network }}"
             {{- end }}
-            {{ if .ObjectMeta.Annotations }}
-            - name: ISTIO_METAJSON_ANNOTATIONS
-              value: |
-                     {{ toJSON .ObjectMeta.Annotations }}
-            {{ end }}
             {{- if .DeploymentMeta.Name }}
             - name: ISTIO_META_WORKLOAD_NAME
               value: "{{ .DeploymentMeta.Name }}"
@@ -7154,7 +7130,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: gcr.io/istio-testing/proxyv2:1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0
+          image: gcr.io/istio-testing/proxyv2:1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7330,6 +7306,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
@@ -7344,9 +7322,7 @@ spec:
               value: "true"
             - name: CLUSTER_ID
               value: Kubernetes
-            - name: EXTERNAL_ISTIOD
-              value: "false"
-          image: gcr.io/istio-testing/pilot:1.11-alpha.f177e200f0e78b4be3e1ead48b7d8ac2951d92e0
+          image: gcr.io/istio-testing/pilot:1.11-alpha.b18a9b08f9fda5463c2bd33afa44130dfd222f58
           name: discovery
           ports:
             - containerPort: 8080
@@ -7550,6 +7526,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7585,6 +7562,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7622,6 +7600,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:
@@ -7655,6 +7634,7 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: /inject
+        port: 443
       caBundle: ""
     sideEffects: None
     rules:

--- a/third_party/istio-latest/istio-ci-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-mesh.yaml
@@ -24,6 +24,8 @@ spec:
       autoscaleMax: 10
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-latest/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/istio.yaml
@@ -4975,9 +4975,9 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
-            - name: PILOT_ENABLED_SERVICE_APIS
-              value: "true"
             - name: PILOT_ENABLE_STATUS
+              value: "true"
+            - name: PILOT_ENABLED_SERVICE_APIS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"

--- a/third_party/istio-latest/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/istio.yaml
@@ -4975,6 +4975,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING

--- a/third_party/istio-latest/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/istio.yaml
@@ -4975,9 +4975,9 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
-            - name: PILOT_ENABLE_STATUS
-              value: "true"
             - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
+            - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"

--- a/third_party/istio-latest/istio-ci-no-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh.yaml
@@ -21,6 +21,8 @@ spec:
       autoscaleMax: 10
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
@@ -4974,6 +4974,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING

--- a/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
@@ -4974,9 +4974,9 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
-            - name: PILOT_ENABLED_SERVICE_APIS
-              value: "true"
             - name: PILOT_ENABLE_STATUS
+              value: "true"
+            - name: PILOT_ENABLED_SERVICE_APIS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"

--- a/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
@@ -4974,9 +4974,9 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
-            - name: PILOT_ENABLE_STATUS
-              value: "true"
             - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
+            - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"

--- a/third_party/istio-latest/istio-kind-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-mesh.yaml
@@ -24,6 +24,8 @@ spec:
       autoscaleMax: 3
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-latest/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-mesh/istio.yaml
@@ -4977,6 +4977,8 @@ spec:
               value: /var/run/secrets/remote/config
             - name: PILOT_ENABLE_STATUS
               value: "true"
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"
             - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND

--- a/third_party/istio-latest/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-mesh/istio.yaml
@@ -4975,9 +4975,9 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
-            - name: PILOT_ENABLE_STATUS
-              value: "true"
             - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
+            - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"

--- a/third_party/istio-latest/istio-kind-no-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh.yaml
@@ -24,6 +24,8 @@ spec:
       autoscaleMax: 3
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -4974,6 +4974,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -4974,9 +4974,9 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
-            - name: PILOT_ENABLED_SERVICE_APIS
-              value: "true"
             - name: PILOT_ENABLE_STATUS
+              value: "true"
+            - name: PILOT_ENABLED_SERVICE_APIS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -4974,9 +4974,9 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
-            - name: PILOT_ENABLE_STATUS
-              value: "true"
             - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
+            - name: PILOT_ENABLE_STATUS
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"

--- a/third_party/istio-stable/istio-ci-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-mesh.yaml
@@ -24,6 +24,8 @@ spec:
       autoscaleMax: 10
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-stable/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-ci-mesh/istio.yaml
@@ -4651,44 +4651,39 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
+        sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod-service-account
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.9.1
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -4696,20 +4691,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -4734,6 +4715,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"
             - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
@@ -4748,34 +4731,53 @@ spec:
               value: Kubernetes
             - name: EXTERNAL_ISTIOD
               value: "false"
+          image: docker.io/istio/pilot:1.9.1
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: config-volume
-              mountPath: /etc/istio/config
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /etc/istio/config
+              name: config-volume
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: inject
-              mountPath: /var/lib/istio/inject
+            - mountPath: /var/lib/istio/inject
+              name: inject
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod-service-account
       volumes:
         - emptyDir:
             medium: Memory
@@ -4789,18 +4791,18 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
-        - name: inject
-          configMap:
+            secretName: istio-kubeconfig
+        - configMap:
             name: istio-sidecar-injector
-        - name: config-volume
-          configMap:
+          name: inject
+        - configMap:
             name: istio
+          name: config-volume
 ---
 apiVersion: v1
 kind: Service

--- a/third_party/istio-stable/istio-ci-no-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh.yaml
@@ -21,6 +21,8 @@ spec:
       autoscaleMax: 10
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-stable/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh/istio.yaml
@@ -4650,44 +4650,39 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
+        sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod-service-account
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.9.1
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -4695,20 +4690,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -4733,6 +4714,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"
             - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
@@ -4747,34 +4730,53 @@ spec:
               value: Kubernetes
             - name: EXTERNAL_ISTIOD
               value: "false"
+          image: docker.io/istio/pilot:1.9.1
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: config-volume
-              mountPath: /etc/istio/config
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /etc/istio/config
+              name: config-volume
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: inject
-              mountPath: /var/lib/istio/inject
+            - mountPath: /var/lib/istio/inject
+              name: inject
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod-service-account
       volumes:
         - emptyDir:
             medium: Memory
@@ -4788,18 +4790,18 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
-        - name: inject
-          configMap:
+            secretName: istio-kubeconfig
+        - configMap:
             name: istio-sidecar-injector
-        - name: config-volume
-          configMap:
+          name: inject
+        - configMap:
             name: istio
+          name: config-volume
 ---
 apiVersion: v1
 kind: Service

--- a/third_party/istio-stable/istio-kind-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-mesh.yaml
@@ -24,6 +24,8 @@ spec:
       autoscaleMax: 3
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-stable/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-kind-mesh/istio.yaml
@@ -4651,44 +4651,39 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
+        sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod-service-account
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.9.1
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -4696,20 +4691,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -4734,6 +4715,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"
             - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
@@ -4748,34 +4731,53 @@ spec:
               value: Kubernetes
             - name: EXTERNAL_ISTIOD
               value: "false"
+          image: docker.io/istio/pilot:1.9.1
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: config-volume
-              mountPath: /etc/istio/config
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /etc/istio/config
+              name: config-volume
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: inject
-              mountPath: /var/lib/istio/inject
+            - mountPath: /var/lib/istio/inject
+              name: inject
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod-service-account
       volumes:
         - emptyDir:
             medium: Memory
@@ -4789,18 +4791,18 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
-        - name: inject
-          configMap:
+            secretName: istio-kubeconfig
+        - configMap:
             name: istio-sidecar-injector
-        - name: config-volume
-          configMap:
+          name: inject
+        - configMap:
             name: istio
+          name: config-volume
 ---
 apiVersion: v1
 kind: Service

--- a/third_party/istio-stable/istio-kind-no-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh.yaml
@@ -24,6 +24,8 @@ spec:
       autoscaleMax: 3
       cpu:
         targetAverageUtilization: 60
+      env:
+        PILOT_ENABLED_SERVICE_APIS: true
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false

--- a/third_party/istio-stable/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh/istio.yaml
@@ -4650,44 +4650,39 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
+        sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod-service-account
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.9.1
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -4695,20 +4690,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -4733,6 +4714,8 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: KUBECONFIG
               value: /var/run/secrets/remote/config
+            - name: PILOT_ENABLED_SERVICE_APIS
+              value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"
             - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
@@ -4747,34 +4730,53 @@ spec:
               value: Kubernetes
             - name: EXTERNAL_ISTIOD
               value: "false"
+          image: docker.io/istio/pilot:1.9.1
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: config-volume
-              mountPath: /etc/istio/config
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /etc/istio/config
+              name: config-volume
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: inject
-              mountPath: /var/lib/istio/inject
+            - mountPath: /var/lib/istio/inject
+              name: inject
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod-service-account
       volumes:
         - emptyDir:
             medium: Memory
@@ -4788,18 +4790,18 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
-        - name: inject
-          configMap:
+            secretName: istio-kubeconfig
+        - configMap:
             name: istio-sidecar-injector
-        - name: config-volume
-          configMap:
+          name: inject
+        - configMap:
             name: istio
+          name: config-volume
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Istio needs this option to support Gateway API (Ingress v2).
If istio manifest could enable the option by default, serving repo
will add Gateway API support with the manifest in net-istio wihtout
change.

/cc @arturenault @dprotaso @markusthoemmes 