### PR TITLE
Replace golint with revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,9 +11,9 @@ linters:
   enable:
     - asciicheck
     - errorlint
-    - golint
     - gosec
     - prealloc
+    - revive
     - stylecheck
     - unconvert
     - unparam


### PR DESCRIPTION
# Changes

See https://groups.google.com/g/golang-nuts/c/rCP70Aq_tBc/m/8QHp6_cqBgAJ
as towards golint's deprecation. revive is supposed to be a drop-in
replacement.

/assign @nak3 