### PR TITLE
Set "disable-gateway-port-translation" label on local gateway Service

### DIFF
--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -42,6 +42,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
+    experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
This was added to Istio in https://github.com/istio/istio/pull/33021. It
will likely be available in 1.9.next and 1.10.next, but if the label is
present with an older Istio version its not a problem - it will just not
have any impact.

What this does is avoid the ambiguities we currently have with the
Gateway service selection. Currently, if the local gateway is created
before the external gateway, we will be broken because the "port 80"
Gateway will match the local gateway and get translated to port 8081,
when it should be translated to port 8080 of the external gateway.

What this label does is tell Istio that the local gateway service is not
eligible for this port translation; as a result, Gateways on port 80
will never be mapped to port 8081. Instead, we expect that port 8081
will be used explicitly in the Gateway, as we do here.

tl;dr:
* Before: NACK if services created in wrong order
* After: service order does not matter

Note: the "experimental" label may be a red flag - this was intended to
be a scary label to dissuade any *other* than Knative from using it. The
label was made specifically to support Knative.

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
