### PR TITLE
Use spec.HTTPOption in KIngress instead of global option

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -151,7 +151,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 		// same wildcard host. We need to handle wildcard certificate specially because Istio does
 		// not fully support multiple TLS Servers (or Gateways) share the same certificate.
 		// https://istio.io/docs/ops/common-problems/network-issues/
-		desiredWildcardGateways, err := resources.MakeWildcardGateways(ctx, wildcardSecrets, r.svcLister)
+		desiredWildcardGateways, err := resources.MakeWildcardGateways(ctx, wildcardSecrets, r.svcLister, ing.Spec.HTTPOption)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 	// TODO(zhiminx): figure out a better way to handle HTTP behavior.
 	// https://github.com/knative/serving/issues/6373
 	if config.FromContext(ctx).Network.AutoTLS {
-		desiredHTTPServer := resources.MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol, []string{"*"})
+		desiredHTTPServer := resources.MakeHTTPServer(ing.Spec.HTTPOption, []string{"*"})
 		for _, gw := range config.FromContext(ctx).Istio.IngressGateways {
 			if err := r.reconcileHTTPServer(ctx, ing, gw, desiredHTTPServer); err != nil {
 				return err

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -292,15 +292,15 @@ func TestMakeTLSServers(t *testing.T) {
 func TestMakeHTTPServer(t *testing.T) {
 	cases := []struct {
 		name         string
-		httpProtocol network.HTTPProtocol
+		httpProtocol v1alpha1.HTTPOption
 		expected     *istiov1alpha3.Server
 	}{{
 		name:         "nil HTTP Server",
-		httpProtocol: network.HTTPDisabled,
+		httpProtocol: "",
 		expected:     nil,
 	}, {
 		name:         "HTTP server",
-		httpProtocol: network.HTTPEnabled,
+		httpProtocol: v1alpha1.HTTPOptionEnabled,
 		expected: &istiov1alpha3.Server{
 			Hosts: []string{"*"},
 			Port: &istiov1alpha3.Port{
@@ -311,7 +311,7 @@ func TestMakeHTTPServer(t *testing.T) {
 		},
 	}, {
 		name:         "Redirect HTTP server",
-		httpProtocol: network.HTTPRedirected,
+		httpProtocol: v1alpha1.HTTPOptionRedirected,
 		expected: &istiov1alpha3.Server{
 			Hosts: []string{"*"},
 			Port: &istiov1alpha3.Port{
@@ -675,7 +675,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 			},
 		})
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := MakeWildcardGateways(ctx, tc.wildcardSecrets, svcLister)
+			got, err := MakeWildcardGateways(ctx, tc.wildcardSecrets, svcLister, v1alpha1.HTTPOptionEnabled)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("Test: %s; MakeWildcardGateways error = %v, WantErr %v", tc.name, err, tc.wantErr)
 			}

--- a/test/config/config-network.yaml
+++ b/test/config/config-network.yaml
@@ -17,3 +17,5 @@ kind: ConfigMap
 metadata:
   name: config-network
   namespace: knative-serving
+data:
+  autoTLS: "Enabled" # TODO: Remove this by solving https://github.com/knative/serving/issues/6373.

--- a/test/config/config-network.yaml
+++ b/test/config/config-network.yaml
@@ -17,5 +17,3 @@ kind: ConfigMap
 metadata:
   name: config-network
   namespace: knative-serving
-data:
-  autoTLS: "Enabled" # TODO: Remove this by solving https://github.com/knative/serving/issues/6373.


### PR DESCRIPTION
This patch changes to use `spec.HTTPOption` in KIngress instead of
global `httpProtocol` for setting HTTP behavior.

Part of https://github.com/knative/networking/issues/302

Note this patch does not change this TODO comment as it needs a tons of unit test change.

https://github.com/knative-sandbox/net-istio/blob/82f58eb4fb0f8fa44d2b59065058d0adf874a134/pkg/reconciler/ingress/ingress.go#L159-L162