### PR TITLE
No need to create HTTP server for wildcard gateway

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -151,7 +151,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 		// same wildcard host. We need to handle wildcard certificate specially because Istio does
 		// not fully support multiple TLS Servers (or Gateways) share the same certificate.
 		// https://istio.io/docs/ops/common-problems/network-issues/
-		desiredWildcardGateways, err := resources.MakeWildcardGateways(ctx, wildcardSecrets, r.svcLister)
+		desiredWildcardGateways, err := resources.MakeWildcardTLSGateways(ctx, wildcardSecrets, r.svcLister)
 		if err != nil {
 			return err
 		}

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -139,7 +139,7 @@ func MakeWildcardTLSGateways(ctx context.Context, originWildcardSecrets map[stri
 	}
 	gateways := []*v1alpha3.Gateway{}
 	for _, gatewayService := range gatewayServices {
-		gws, err := makeWildcardTLSGateways(ctx, originWildcardSecrets, gatewayService)
+		gws, err := makeWildcardTLSGateways(originWildcardSecrets, gatewayService)
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +148,7 @@ func MakeWildcardTLSGateways(ctx context.Context, originWildcardSecrets map[stri
 	return gateways, nil
 }
 
-func makeWildcardTLSGateways(ctx context.Context, originWildcardSecrets map[string]*corev1.Secret,
+func makeWildcardTLSGateways(originWildcardSecrets map[string]*corev1.Secret,
 	gatewayService *corev1.Service) ([]*v1alpha3.Gateway, error) {
 	gateways := make([]*v1alpha3.Gateway, 0, len(originWildcardSecrets))
 	for _, secret := range originWildcardSecrets {

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -126,9 +126,9 @@ func MakeIngressTLSGateways(ctx context.Context, ing *v1alpha1.Ingress, ingressT
 	return gateways, nil
 }
 
-// MakeWildcardGateways creates gateways with wildcard hosts based on the wildcard secret information.
+// MakeWildcardTLSGateways creates gateways that only contain TLS server with wildcard hosts based on the wildcard secret information.
 // For each public ingress service, we will create a list of Gateways. Each Gateway of the list corresponds to a wildcard cert secret.
-func MakeWildcardGateways(ctx context.Context, originWildcardSecrets map[string]*corev1.Secret,
+func MakeWildcardTLSGateways(ctx context.Context, originWildcardSecrets map[string]*corev1.Secret,
 	svcLister corev1listers.ServiceLister) ([]*v1alpha3.Gateway, error) {
 	if len(originWildcardSecrets) == 0 {
 		return []*v1alpha3.Gateway{}, nil
@@ -139,7 +139,7 @@ func MakeWildcardGateways(ctx context.Context, originWildcardSecrets map[string]
 	}
 	gateways := []*v1alpha3.Gateway{}
 	for _, gatewayService := range gatewayServices {
-		gws, err := makeWildcardGateways(ctx, originWildcardSecrets, gatewayService)
+		gws, err := makeWildcardTLSGateways(ctx, originWildcardSecrets, gatewayService)
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +148,7 @@ func MakeWildcardGateways(ctx context.Context, originWildcardSecrets map[string]
 	return gateways, nil
 }
 
-func makeWildcardGateways(ctx context.Context, originWildcardSecrets map[string]*corev1.Secret,
+func makeWildcardTLSGateways(ctx context.Context, originWildcardSecrets map[string]*corev1.Secret,
 	gatewayService *corev1.Service) ([]*v1alpha3.Gateway, error) {
 	gateways := make([]*v1alpha3.Gateway, 0, len(originWildcardSecrets))
 	for _, secret := range originWildcardSecrets {
@@ -176,10 +176,6 @@ func makeWildcardGateways(ctx context.Context, originWildcardSecrets map[string]
 				CredentialName:    credentialName,
 			},
 		}}
-		httpServer := MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol, hosts)
-		if httpServer != nil {
-			servers = append(servers, httpServer)
-		}
 		gvk := schema.GroupVersionKind{Version: "v1", Kind: "Secret"}
 		gateways = append(gateways, &v1alpha3.Gateway{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -591,13 +591,6 @@ func TestMakeWildcardGateways(t *testing.T) {
 						PrivateKey:        corev1.TLSPrivateKeyKey,
 						CredentialName:    targetWildcardSecretName(wildcardSecret.Name, wildcardSecret.Namespace),
 					},
-				}, {
-					Hosts: []string{"*.example.com"},
-					Port: &istiov1alpha3.Port{
-						Name:     httpServerPortName,
-						Number:   80,
-						Protocol: "HTTP",
-					},
 				}},
 			},
 		}},
@@ -634,13 +627,6 @@ func TestMakeWildcardGateways(t *testing.T) {
 						PrivateKey:        corev1.TLSPrivateKeyKey,
 						CredentialName:    wildcardSecret.Name,
 					},
-				}, {
-					Hosts: []string{"*.example.com"},
-					Port: &istiov1alpha3.Port{
-						Name:     httpServerPortName,
-						Number:   80,
-						Protocol: "HTTP",
-					},
 				}},
 			},
 		}},
@@ -675,7 +661,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 			},
 		})
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := MakeWildcardGateways(ctx, tc.wildcardSecrets, svcLister)
+			got, err := MakeWildcardTLSGateways(ctx, tc.wildcardSecrets, svcLister)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("Test: %s; MakeWildcardGateways error = %v, WantErr %v", tc.name, err, tc.wantErr)
 			}


### PR DESCRIPTION
For the wildcard Gateway case, a VirtualService ties to both the wildcard Gateway as well as the default global Gateway. (see https://github.com/knative-sandbox/net-istio/blob/main/pkg/reconciler/ingress/ingress.go#L115)

When auto TLS is enabled, the HTTP server of the global Gateway is reconciled to desired shape. So there is no need to add the desired HTTP server to the wildcard Gateway.

/cc @nak3 