### PR TITLE
Use terminationDrainDuration in MeshConfig.defaultConfig

### DIFF
--- a/third_party/istio-head/istio-ci-mesh.yaml
+++ b/third_party/istio-head/istio-ci-mesh.yaml
@@ -30,17 +30,13 @@ spec:
 
   meshConfig:
     defaultConfig:
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      terminationDrainDuration: "20s"
 
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 3
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-head/istio-ci-no-mesh.yaml
+++ b/third_party/istio-head/istio-ci-no-mesh.yaml
@@ -25,14 +25,15 @@ spec:
       istio-ingressgateway:
         autoscaleEnabled: false
 
+  meshConfig:
+    defaultConfig:
+      terminationDrainDuration: "20s"
+
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 3
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-head/istio-kind-mesh.yaml
+++ b/third_party/istio-head/istio-kind-mesh.yaml
@@ -18,7 +18,6 @@ spec:
   values:
     global:
       proxy:
-        autoInject: enabled
         clusterDomain: cluster.local
     pilot:
       autoscaleMin: 1
@@ -32,17 +31,13 @@ spec:
 
   meshConfig:
     defaultConfig:
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      terminationDrainDuration: "20s"
 
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 1
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-head/istio-kind-no-mesh.yaml
+++ b/third_party/istio-head/istio-kind-no-mesh.yaml
@@ -29,14 +29,15 @@ spec:
         autoscaleEnabled: false
         type: NodePort
 
+  meshConfig:
+    defaultConfig:
+      terminationDrainDuration: "20s"
+
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 1
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-latest/istio-ci-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-mesh.yaml
@@ -30,17 +30,13 @@ spec:
 
   meshConfig:
     defaultConfig:
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      terminationDrainDuration: "20s"
 
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 3
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-latest/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/istio.yaml
@@ -6112,8 +6112,8 @@ data:
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      proxyMetadata: {}
+      terminationDrainDuration: 20s
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
@@ -7151,8 +7151,6 @@ spec:
               value: "true"
             - name: ISTIO_META_ROUTER_MODE
               value: standard
-            - name: TERMINATION_DRAIN_DURATION_SECONDS
-              value: "20"
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
           image: docker.io/istio/proxyv2:1.10.1

--- a/third_party/istio-latest/istio-ci-no-mesh.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh.yaml
@@ -25,14 +25,15 @@ spec:
       istio-ingressgateway:
         autoscaleEnabled: false
 
+  meshConfig:
+    defaultConfig:
+      terminationDrainDuration: "20s"
+
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 3
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
@@ -6113,6 +6113,7 @@ data:
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
       proxyMetadata: {}
+      terminationDrainDuration: 20s
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
@@ -7095,8 +7096,6 @@ spec:
             - --serviceCluster
             - istio-ingressgateway
           env:
-            - name: TERMINATION_DRAIN_DURATION_SECONDS
-              value: "20"
             - name: JWT_POLICY
               value: third-party-jwt
             - name: PILOT_CERT_PROVIDER

--- a/third_party/istio-latest/istio-kind-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-mesh.yaml
@@ -31,17 +31,13 @@ spec:
 
   meshConfig:
     defaultConfig:
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      terminationDrainDuration: "20s"
 
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 1
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-latest/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-mesh/istio.yaml
@@ -6112,8 +6112,8 @@ data:
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      proxyMetadata: {}
+      terminationDrainDuration: 20s
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
@@ -7151,8 +7151,6 @@ spec:
               value: "true"
             - name: ISTIO_META_ROUTER_MODE
               value: standard
-            - name: TERMINATION_DRAIN_DURATION_SECONDS
-              value: "20"
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
           image: docker.io/istio/proxyv2:1.10.1

--- a/third_party/istio-latest/istio-kind-no-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh.yaml
@@ -29,14 +29,15 @@ spec:
         autoscaleEnabled: false
         type: NodePort
 
+  meshConfig:
+    defaultConfig:
+      terminationDrainDuration: "20s"
+
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 1
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -6113,6 +6113,7 @@ data:
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
       proxyMetadata: {}
+      terminationDrainDuration: 20s
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
@@ -7095,8 +7096,6 @@ spec:
             - --serviceCluster
             - istio-ingressgateway
           env:
-            - name: TERMINATION_DRAIN_DURATION_SECONDS
-              value: "20"
             - name: JWT_POLICY
               value: third-party-jwt
             - name: PILOT_CERT_PROVIDER

--- a/third_party/istio-stable/istio-ci-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-mesh.yaml
@@ -30,17 +30,13 @@ spec:
 
   meshConfig:
     defaultConfig:
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      terminationDrainDuration: "20s"
 
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 3
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-stable/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-ci-mesh/istio.yaml
@@ -3730,8 +3730,8 @@ data:
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      proxyMetadata: {}
+      terminationDrainDuration: 20s
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
@@ -4765,8 +4765,6 @@ spec:
               value: "true"
             - name: ISTIO_META_ROUTER_MODE
               value: standard
-            - name: TERMINATION_DRAIN_DURATION_SECONDS
-              value: "20"
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
           image: docker.io/istio/proxyv2:1.9.5

--- a/third_party/istio-stable/istio-ci-no-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh.yaml
@@ -25,14 +25,15 @@ spec:
       istio-ingressgateway:
         autoscaleEnabled: false
 
+  meshConfig:
+    defaultConfig:
+      terminationDrainDuration: "20s"
+
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 3
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             limits:
               cpu: 3000m

--- a/third_party/istio-stable/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh/istio.yaml
@@ -3731,6 +3731,7 @@ data:
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
       proxyMetadata: {}
+      terminationDrainDuration: 20s
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
@@ -4713,8 +4714,6 @@ spec:
             - --serviceCluster
             - istio-ingressgateway
           env:
-            - name: TERMINATION_DRAIN_DURATION_SECONDS
-              value: "20"
             - name: JWT_POLICY
               value: third-party-jwt
             - name: PILOT_CERT_PROVIDER

--- a/third_party/istio-stable/istio-kind-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-mesh.yaml
@@ -31,17 +31,13 @@ spec:
 
   meshConfig:
     defaultConfig:
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      terminationDrainDuration: "20s"
 
   components:
     ingressGateways:
       - name: istio-ingressgateway
         k8s:
           replicaCount: 1
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-stable/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-kind-mesh/istio.yaml
@@ -3730,8 +3730,8 @@ data:
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
-      proxyMetadata:
-        TERMINATION_DRAIN_DURATION_SECONDS: "20"
+      proxyMetadata: {}
+      terminationDrainDuration: 20s
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
@@ -4765,8 +4765,6 @@ spec:
               value: "true"
             - name: ISTIO_META_ROUTER_MODE
               value: standard
-            - name: TERMINATION_DRAIN_DURATION_SECONDS
-              value: "20"
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
           image: docker.io/istio/proxyv2:1.9.5

--- a/third_party/istio-stable/istio-kind-no-mesh.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh.yaml
@@ -29,15 +29,15 @@ spec:
         autoscaleEnabled: false
         type: NodePort
 
+  meshConfig:
+    defaultConfig:
+      terminationDrainDuration: "20s"
+
   components:
     ingressGateways:
       - name: istio-ingressgateway
-        enabled: true
         k8s:
           replicaCount: 1
-          env:
-            - name: 'TERMINATION_DRAIN_DURATION_SECONDS'
-              value: '20'
           resources:
             requests:
               cpu: 100m

--- a/third_party/istio-stable/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh/istio.yaml
@@ -3731,6 +3731,7 @@ data:
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
       proxyMetadata: {}
+      terminationDrainDuration: 20s
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
@@ -4713,8 +4714,6 @@ spec:
             - --serviceCluster
             - istio-ingressgateway
           env:
-            - name: TERMINATION_DRAIN_DURATION_SECONDS
-              value: "20"
             - name: JWT_POLICY
               value: third-party-jwt
             - name: PILOT_CERT_PROVIDER


### PR DESCRIPTION
Istio upstream drops `TERMINATION_DRAIN_DURATION_SECONDS` since 1.10
https://github.com/istio/istio/commit/f6502508b04c38f9678c300821dd54e439b832ed.

/kind cleanup