### PR TITLE
Fix deprecation lint error

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -1651,7 +1651,7 @@ func TestGlobalResyncOnUpdateGatewayConfigMap(t *testing.T) {
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatal("Failed to start ingress manager:", err)
 	}
-	grp.Go(func() error { return ctrl.Run(1, ctx.Done()) })
+	grp.Go(func() error { return ctrl.RunContext(ctx, 1) })
 
 	ingress := ingressWithStatus("config-update",
 		v1alpha1.IngressStatus{
@@ -1752,7 +1752,7 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 		t.Fatal("Failed to start watcher:", err)
 	}
 
-	grp.Go(func() error { return ctrl.Run(1, ctx.Done()) })
+	grp.Go(func() error { return ctrl.RunContext(ctx, 1) })
 
 	ingress := ingressWithTLSAndStatus("reconciling-ingress",
 		ingressTLS,


### PR DESCRIPTION
This patch fixes the lint error:

https://github.com/knative-sandbox/net-istio/runs/3375284605?check_suite_focus=true

It is same fix with https://github.com/knative/serving/commit/d9328556ad0944de268a975d32ed9883a727e26b

/cc @ZhiminXiang @tcnghia @markusthoemmes 