### PR TITLE
Use GKE 1.20 for CI

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,7 +18,7 @@ source $(dirname $0)/e2e-common.sh
 
 
 # Script entry point.
-initialize $@  --skip-istio-addon
+initialize $@  --skip-istio-addon --cluster-version=1.20
 
 # TODO Re-enable conformance tests for mesh when everything's been fixed
 # https://github.com/knative-sandbox/net-istio/issues/584


### PR DESCRIPTION
Current CI is very unstable as https://testgrid.k8s.io/r/knative-own-testgrid/net-istio#latest
This patch changes to use GKE 1.20.