### PR TITLE
Mark `local-gateway.mesh: mesh` deprecated

### DIFF
--- a/config/400-config-istio.yaml
+++ b/config/400-config-istio.yaml
@@ -62,6 +62,9 @@ data:
     # `knative-serving`
     local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.istio-system.svc.cluster.local"
 
+    # DEPRECATED: local-gateway.mesh is deprecated.
+    # See: https://github.com/knative/serving/issues/11523
+    #
     # To use only Istio service mesh and no knative-local-gateway, replace
     # all local-gateway.* entries by the following entry.
     local-gateway.mesh: "mesh"


### PR DESCRIPTION
As per https://github.com/knative/serving/issues/11523, this patch marks `local-gateway.mesh: "mesh"` deprecated.

/cc @ZhiminXiang 

**Release Note**

```release-note
`local-gateway.mesh: "mesh"` in `config-istio` is deprecated. 
```
