### PR TITLE
Bump Istio to 1.11.3 and 1.10.5

### DIFF
--- a/third_party/istio-latest/generate-manifests.sh
+++ b/third_party/istio-latest/generate-manifests.sh
@@ -16,6 +16,6 @@
 
 source "$(dirname $0)/../library.sh"
 
-generate "1.11.0" "$(dirname $0)" \
+generate "1.11.4" "$(dirname $0)" \
       --set values.pilot.env.PILOT_ENABLE_STATUS=true \
       --set values.global.istiod.enableAnalysis=true \

--- a/third_party/istio-latest/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/istio.yaml
@@ -6337,7 +6337,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.11.0",
+        "tag": "1.11.4",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -7489,7 +7489,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.11.0
+          image: docker.io/istio/proxyv2:1.11.4
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7669,7 +7669,7 @@ spec:
               value: "true"
             - name: CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/pilot:1.11.0
+          image: docker.io/istio/pilot:1.11.4
           name: discovery
           ports:
             - containerPort: 8080

--- a/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
@@ -6337,7 +6337,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.11.0",
+        "tag": "1.11.4",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -7489,7 +7489,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.11.0
+          image: docker.io/istio/proxyv2:1.11.4
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7669,7 +7669,7 @@ spec:
               value: "true"
             - name: CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/pilot:1.11.0
+          image: docker.io/istio/pilot:1.11.4
           name: discovery
           ports:
             - containerPort: 8080

--- a/third_party/istio-latest/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-mesh/istio.yaml
@@ -6337,7 +6337,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.11.0",
+        "tag": "1.11.4",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -7489,7 +7489,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.11.0
+          image: docker.io/istio/proxyv2:1.11.4
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7669,7 +7669,7 @@ spec:
               value: "true"
             - name: CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/pilot:1.11.0
+          image: docker.io/istio/pilot:1.11.4
           name: discovery
           ports:
             - containerPort: 8080

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -6337,7 +6337,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.11.0",
+        "tag": "1.11.4",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -7489,7 +7489,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.11.0
+          image: docker.io/istio/proxyv2:1.11.4
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7669,7 +7669,7 @@ spec:
               value: "true"
             - name: CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/pilot:1.11.0
+          image: docker.io/istio/pilot:1.11.4
           name: discovery
           ports:
             - containerPort: 8080

--- a/third_party/istio-stable/generate-manifests.sh
+++ b/third_party/istio-stable/generate-manifests.sh
@@ -16,4 +16,4 @@
 
 source "$(dirname $0)/../library.sh"
 
-generate "1.10.3" "$(dirname $0)"
+generate "1.10.5" "$(dirname $0)"

--- a/third_party/istio-stable/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-ci-mesh/istio.yaml
@@ -6198,7 +6198,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.10.3",
+        "tag": "1.10.5",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -7126,7 +7126,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.10.3
+          image: docker.io/istio/proxyv2:1.10.5
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7274,7 +7274,7 @@ spec:
         fsGroup: 1337
       containers:
         - name: discovery
-          image: docker.io/istio/pilot:1.10.3
+          image: docker.io/istio/pilot:1.10.5
           args:
             - discovery
             - --monitoringAddr=:15014

--- a/third_party/istio-stable/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh/istio.yaml
@@ -6198,7 +6198,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.10.3",
+        "tag": "1.10.5",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -7126,7 +7126,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.10.3
+          image: docker.io/istio/proxyv2:1.10.5
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7274,7 +7274,7 @@ spec:
         fsGroup: 1337
       containers:
         - name: discovery
-          image: docker.io/istio/pilot:1.10.3
+          image: docker.io/istio/pilot:1.10.5
           args:
             - discovery
             - --monitoringAddr=:15014

--- a/third_party/istio-stable/istio-kind-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-kind-mesh/istio.yaml
@@ -6198,7 +6198,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.10.3",
+        "tag": "1.10.5",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -7126,7 +7126,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.10.3
+          image: docker.io/istio/proxyv2:1.10.5
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7274,7 +7274,7 @@ spec:
         fsGroup: 1337
       containers:
         - name: discovery
-          image: docker.io/istio/pilot:1.10.3
+          image: docker.io/istio/pilot:1.10.5
           args:
             - discovery
             - --monitoringAddr=:15014

--- a/third_party/istio-stable/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-stable/istio-kind-no-mesh/istio.yaml
@@ -6198,7 +6198,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.10.3",
+        "tag": "1.10.5",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -7126,7 +7126,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.10.3
+          image: docker.io/istio/proxyv2:1.10.5
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -7274,7 +7274,7 @@ spec:
         fsGroup: 1337
       containers:
         - name: discovery
-          image: docker.io/istio/pilot:1.10.3
+          image: docker.io/istio/pilot:1.10.5
           args:
             - discovery
             - --monitoringAddr=:15014


### PR DESCRIPTION
This patch bumps Istio version to 1.11.3(latest) and 1.10.5(stable).

Fix https://github.com/knative-sandbox/net-istio/issues/775 https://github.com/knative-sandbox/net-istio/issues/738