### PR TITLE
Revert "Use GKE 1.20 (#781)"

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,7 +18,7 @@ source $(dirname $0)/e2e-common.sh
 
 
 # Script entry point.
-initialize $@  --skip-istio-addon --cluster-version=1.20
+initialize $@  --skip-istio-addon
 
 # TODO Re-enable conformance tests for mesh when everything's been fixed
 # https://github.com/knative-sandbox/net-istio/issues/584


### PR DESCRIPTION
This reverts commit 2c2f2de479e7534a2bba6b04aeecb3efb04557bc.

It seems test became stable. [Contour uses 1.21](https://testgrid.k8s.io/r/knative-own-testgrid/net-contour#continuous) but it is all green recently.