### PR TITLE
Add k8s recommended labels

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -18,8 +18,8 @@ metadata:
   # These are the permissions needed by the Istio Ingress implementation.
   name: knative-serving-istio
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     serving.knative.dev/controller: "true"

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -18,6 +18,9 @@ metadata:
   # These are the permissions needed by the Istio Ingress implementation.
   name: knative-serving-istio
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio

--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -19,6 +19,9 @@ metadata:
   name: knative-ingress-gateway
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:

--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -19,8 +19,8 @@ metadata:
   name: knative-ingress-gateway
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -21,8 +21,8 @@ metadata:
   name: knative-local-gateway
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
@@ -43,8 +43,8 @@ metadata:
   name: knative-local-gateway
   namespace: istio-system
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -21,6 +21,9 @@ metadata:
   name: knative-local-gateway
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
@@ -40,6 +43,9 @@ metadata:
   name: knative-local-gateway
   namespace: istio-system
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"

--- a/config/400-config-istio.yaml
+++ b/config/400-config-istio.yaml
@@ -18,8 +18,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/400-config-istio.yaml
+++ b/config/400-config-istio.yaml
@@ -18,6 +18,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/config/400-webhook-peer-authentication.yaml
+++ b/config/400-webhook-peer-authentication.yaml
@@ -6,8 +6,8 @@ metadata:
   name: "webhook"
   namespace: "knative-serving"
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
@@ -25,8 +25,8 @@ metadata:
   name: "domainmapping-webhook"
   namespace: "knative-serving"
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
@@ -44,8 +44,8 @@ metadata:
   name: "net-istio-webhook"
   namespace: "knative-serving"
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/400-webhook-peer-authentication.yaml
+++ b/config/400-webhook-peer-authentication.yaml
@@ -6,6 +6,9 @@ metadata:
   name: "webhook"
   namespace: "knative-serving"
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
@@ -22,6 +25,9 @@ metadata:
   name: "domainmapping-webhook"
   namespace: "knative-serving"
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
@@ -38,6 +44,9 @@ metadata:
   name: "net-istio-webhook"
   namespace: "knative-serving"
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -18,8 +18,8 @@ metadata:
   name: net-istio-controller
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
@@ -37,8 +37,8 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: net-istio-controller
-        app.kubernetes.io/name: istio
-        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/component: net-istio
+        app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
         serving.knative.dev/release: devel
     spec:

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -18,6 +18,9 @@ metadata:
   name: net-istio-controller
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
@@ -34,6 +37,9 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: net-istio-controller
+        app.kubernetes.io/name: istio
+        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/version: devel
         serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller

--- a/config/500-webhook-deployment.yaml
+++ b/config/500-webhook-deployment.yaml
@@ -18,6 +18,9 @@ metadata:
   name: net-istio-webhook
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
@@ -32,6 +35,9 @@ spec:
       labels:
         app: net-istio-webhook
         role: net-istio-webhook
+        app.kubernetes.io/name: istio
+        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/version: devel
         serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller

--- a/config/500-webhook-deployment.yaml
+++ b/config/500-webhook-deployment.yaml
@@ -18,8 +18,8 @@ metadata:
   name: net-istio-webhook
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
@@ -35,8 +35,8 @@ spec:
       labels:
         app: net-istio-webhook
         role: net-istio-webhook
-        app.kubernetes.io/name: istio
-        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/component: net-istio
+        app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
         serving.knative.dev/release: devel
     spec:

--- a/config/500-webhook-secret.yaml
+++ b/config/500-webhook-secret.yaml
@@ -18,8 +18,8 @@ metadata:
   name: net-istio-webhook-certs
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/500-webhook-secret.yaml
+++ b/config/500-webhook-secret.yaml
@@ -18,5 +18,8 @@ metadata:
   name: net-istio-webhook-certs
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/500-webhook-service.yaml
+++ b/config/500-webhook-service.yaml
@@ -19,6 +19,9 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-istio-webhook
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:

--- a/config/500-webhook-service.yaml
+++ b/config/500-webhook-service.yaml
@@ -19,8 +19,8 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-istio-webhook
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/600-mutating-webhook.yaml
+++ b/config/600-mutating-webhook.yaml
@@ -17,6 +17,9 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.istio.networking.internal.knative.dev
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 webhooks:

--- a/config/600-mutating-webhook.yaml
+++ b/config/600-mutating-webhook.yaml
@@ -17,8 +17,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.istio.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/600-validating-webhook.yaml
+++ b/config/600-validating-webhook.yaml
@@ -17,8 +17,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.istio.networking.internal.knative.dev
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/600-validating-webhook.yaml
+++ b/config/600-validating-webhook.yaml
@@ -17,6 +17,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.istio.networking.internal.knative.dev
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 webhooks:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -35,8 +35,8 @@ readonly RELEASES
 function build_release() {
   # Update release labels if this is a tagged release
   if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|")
+    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\" and app.kubernetes.io/version: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
   else
     echo "Untagged release, will NOT update release labels"
     LABEL_YAML_CMD=(cat)

--- a/pkg/reconciler/ingress/config/testdata/config-istio.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-istio.yaml
@@ -18,8 +18,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/pkg/reconciler/ingress/config/testdata/config-istio.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-istio.yaml
@@ -18,6 +18,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/pkg/reconciler/ingress/config/testdata/config-network.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-network.yaml
@@ -18,8 +18,8 @@ metadata:
   name: config-network
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 

--- a/pkg/reconciler/ingress/config/testdata/config-network.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-network.yaml
@@ -18,6 +18,9 @@ metadata:
   name: config-network
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 
 data:

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -18,6 +18,9 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 ---
 kind: ClusterRole
@@ -37,6 +40,9 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -18,8 +18,8 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 ---
@@ -40,8 +40,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 subjects:

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -18,9 +18,6 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 
 ---
@@ -30,9 +27,6 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
@@ -49,9 +43,6 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -69,9 +60,6 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 spec:
   selector:

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -18,6 +18,9 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: chaosduck
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 
 ---
@@ -27,6 +30,9 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: chaosduck
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
@@ -43,6 +49,9 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: chaosduck
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -60,6 +69,9 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: chaosduck
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 spec:
   selector:

--- a/third_party/istio-head/extra/config-istio-mesh.yaml
+++ b/third_party/istio-head/extra/config-istio-mesh.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-head/extra/config-istio-mesh.yaml
+++ b/third_party/istio-head/extra/config-istio-mesh.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-head/extra/config-istio.yaml
+++ b/third_party/istio-head/extra/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-head/extra/config-istio.yaml
+++ b/third_party/istio-head/extra/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-head/istio-ci-mesh/config-istio.yaml
+++ b/third_party/istio-head/istio-ci-mesh/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-head/istio-ci-mesh/config-istio.yaml
+++ b/third_party/istio-head/istio-ci-mesh/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-head/istio-ci-no-mesh/config-istio.yaml
+++ b/third_party/istio-head/istio-ci-no-mesh/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-head/istio-ci-no-mesh/config-istio.yaml
+++ b/third_party/istio-head/istio-ci-no-mesh/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-head/istio-kind-mesh/config-istio.yaml
+++ b/third_party/istio-head/istio-kind-mesh/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-head/istio-kind-mesh/config-istio.yaml
+++ b/third_party/istio-head/istio-kind-mesh/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-head/istio-kind-no-mesh/config-istio.yaml
+++ b/third_party/istio-head/istio-kind-no-mesh/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-head/istio-kind-no-mesh/config-istio.yaml
+++ b/third_party/istio-head/istio-kind-no-mesh/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-latest/extra/config-istio-mesh.yaml
+++ b/third_party/istio-latest/extra/config-istio-mesh.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-latest/extra/config-istio-mesh.yaml
+++ b/third_party/istio-latest/extra/config-istio-mesh.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-latest/extra/config-istio.yaml
+++ b/third_party/istio-latest/extra/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-latest/extra/config-istio.yaml
+++ b/third_party/istio-latest/extra/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-latest/istio-ci-mesh/config-istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-latest/istio-ci-mesh/config-istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-latest/istio-ci-no-mesh/config-istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-latest/istio-ci-no-mesh/config-istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-latest/istio-kind-mesh/config-istio.yaml
+++ b/third_party/istio-latest/istio-kind-mesh/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-latest/istio-kind-mesh/config-istio.yaml
+++ b/third_party/istio-latest/istio-kind-mesh/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/third_party/istio-latest/istio-kind-no-mesh/config-istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/config-istio.yaml
@@ -5,6 +5,9 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: istio
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:

--- a/third_party/istio-latest/istio-kind-no-mesh/config-istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/config-istio.yaml
@@ -5,8 +5,8 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: istio
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio


### PR DESCRIPTION
# Changes

Adds Kubernetes recommended labels to networking as discussed in https://github.com/knative/networking/issues/552

Note that changes to the labels in `vendor/knative.dev/networking` should be handled by the automation once https://github.com/knative/networking/pull/555 merges. 

/kind enhancement
