### PR TITLE
Exclude skipped targets/hosts from ListProbeTargets

### DIFF
--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -149,9 +149,6 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1alpha3.Gateway) (
 		switch server.Port.Protocol {
 		case "HTTP", "HTTP2":
 			if server.Tls != nil && server.Tls.HttpsRedirect {
-				for _, host := range server.Hosts {
-					excluded.Insert(host)
-				}
 				// ignoring HTTPS redirects.
 				continue
 			}

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -82,12 +82,6 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 			continue
 		}
 		for _, target := range targets {
-			qualifiedTarget := status.ProbeTarget{
-				PodIPs:  target.PodIPs,
-				PodPort: target.PodPort,
-				Port:    target.Port,
-				URLs:    make([]*url.URL, 1),
-			}
 			// Pick a single host since they all end up being used in the same
 			// VirtualService and will be applied atomically by Istio. However,
 			// it's important to choose a hostname which isn't excluded from the
@@ -98,6 +92,15 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 					host = hostName
 					break
 				}
+			}
+			if host == "" {
+				continue
+			}
+			qualifiedTarget := status.ProbeTarget{
+				PodIPs:  target.PodIPs,
+				PodPort: target.PodPort,
+				Port:    target.Port,
+				URLs:    make([]*url.URL, 1),
 			}
 			newURL := *target.URLs[0]
 			newURL.Host = host + ":" + target.Port

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -1264,30 +1264,27 @@ func TestListProbeTargets(t *testing.T) {
 					Name:      "gateway",
 				},
 				Spec: istiov1alpha3.Gateway{
-					Servers: []*istiov1alpha3.Server{
-						{
-							  Hosts: []string{"mutual.example.com"},
-							  Port: &istiov1alpha3.Port{
-								  Name:     "https-mutual",
-								  Number:   8443,
-								  Protocol: "HTTPS",
-							  },
-							  Tls: &istiov1alpha3.ServerTLSSettings{
-								  Mode: istiov1alpha3.ServerTLSSettings_MUTUAL,
-							  },
-						 },
-						{
-							Hosts: []string{"simple.example.com"},
-							Port: &istiov1alpha3.Port{
-								Name:     "https-simple",
-								Number:   8081,
-								Protocol: "HTTPS",
-							},
-							Tls: &istiov1alpha3.ServerTLSSettings{
-								Mode: istiov1alpha3.ServerTLSSettings_SIMPLE,
-							},
+					Servers: []*istiov1alpha3.Server{{
+						Hosts: []string{"mutual.example.com"},
+						Port: &istiov1alpha3.Port{
+							Name:     "https-mutual",
+							Number:   8443,
+							Protocol: "HTTPS",
 						},
-					},
+						Tls: &istiov1alpha3.ServerTLSSettings{
+							Mode: istiov1alpha3.ServerTLSSettings_MUTUAL,
+						},
+					}, {
+						Hosts: []string{"simple.example.com"},
+						Port: &istiov1alpha3.Port{
+							Name:     "https-simple",
+							Number:   8081,
+							Protocol: "HTTPS",
+						},
+						Tls: &istiov1alpha3.ServerTLSSettings{
+							Mode: istiov1alpha3.ServerTLSSettings_SIMPLE,
+						},
+					}},
 					Selector: map[string]string{
 						"gwt": "istio",
 					},
@@ -1340,20 +1337,17 @@ func TestListProbeTargets(t *testing.T) {
 				Name:      "whatever",
 			},
 			Spec: v1alpha1.IngressSpec{
-				Rules: []v1alpha1.IngressRule{
-					{
-						 Hosts: []string{
-							  "mutual.example.com",
-						 },
-						 Visibility: v1alpha1.IngressVisibilityExternalIP,
-					 },
-					{
-						Hosts: []string{
-							"simple.example.com",
-						},
-						Visibility: v1alpha1.IngressVisibilityExternalIP,
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"mutual.example.com",
 					},
-				},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+				}, {
+					Hosts: []string{
+						"simple.example.com",
+					},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+				}},
 			},
 		},
 		results: []status.ProbeTarget{{


### PR DESCRIPTION
# Changes

Exclude the skipped hosts/servers (`MUTUAL`, redirects, etc) from the list of probe targets returned from `ListProbeTargets` so kn doesn't attempt to probe an unresolvable server. The specific side effect/bug that this fixes is described in the following places:

* [GH Issue comment](https://github.com/knative-sandbox/net-istio/issues/719#issuecomment-972834067) - I have not confirmed that this fixes the problem outlined by @nak3 in the first comment, only the second.
* [Slack conversation](https://knative.slack.com/archives/C0186KU7STW/p1637171885256400)

/kind bug