### PR TITLE
Use for string keys instead of integer keys on PeerAuthentications.

### DIFF
--- a/config/400-webhook-peer-authentication.yaml
+++ b/config/400-webhook-peer-authentication.yaml
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       app: webhook
   portLevelMtls:
-    8443:
+    "8443":
       mode: PERMISSIVE
 ---
 apiVersion: "security.istio.io/v1beta1"
@@ -35,7 +35,7 @@ spec:
     matchLabels:
       app: domainmapping-webhook
   portLevelMtls:
-    8443:
+    "8443":
       mode: PERMISSIVE
 ---
 apiVersion: "security.istio.io/v1beta1"
@@ -54,5 +54,5 @@ spec:
     matchLabels:
       app: net-istio-webhook
   portLevelMtls:
-    8443:
+    "8443":
       mode: PERMISSIVE


### PR DESCRIPTION
Due to [Support for integer keys](https://github.com/kubernetes-sigs/kustomize/issues/3446) bug, integer keys can not be used with kustomize.


Ideally, it should be solved on kustomize side, but the solution requires much more work and I think making keys string will not harm anybody. 

<!-- Thanks for sending a pull request! -->

# Changes

PeerAuthentications manifests' spec.portLevelMtls keys are converted to string type from integer.

/kind enhancement

Fixes #840
