### PR TITLE
Bump k8s version to 1.23.0 in kind

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.20.7
         - v1.21.1
         - v1.22.0
+        - v1.23.0
 
         test-suite:
         - ./test/conformance
@@ -35,15 +35,15 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.20.7
-          kind-version: v0.11.1
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
         - k8s-version: v1.21.1
           kind-version: v0.11.1
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
         - k8s-version: v1.22.0
           kind-version: v0.11.1
           kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
+        - k8s-version: v1.23.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
 
 
 


### PR DESCRIPTION
As k8s min version was bumped to 1.21 by https://github.com/knative/pkg/pull/2397, this patch bumps k8s version in kind.