### PR TITLE
Updates val webhook selector to reduce invocations

### DIFF
--- a/config/600-validating-webhook.yaml
+++ b/config/600-validating-webhook.yaml
@@ -33,6 +33,7 @@ webhooks:
   failurePolicy: Fail
   sideEffects: None
   name: config.webhook.istio.networking.internal.knative.dev
-  namespaceSelector:
+  objectSelector:
     matchLabels:
       app.kubernetes.io/name: knative-serving
+      app.kubernetes.io/component: net-istio


### PR DESCRIPTION
# Changes

When we install net-istio with serving, multiple validating
webhooks are registered.

Previously, the webhooks were configured with just namespace
selectors that are identical. Thus when config-istio is updated,
the serving webhook is invoked (which is a noop) and vice-versa
for any serving config maps.

To avoid this, this PR updates the validating webhook to use an
objectSelector and includes an extra label (`component:net-istio`)
to further distinguish net-istio resources from serving resources.

/kind cleanup

Part of https://github.com/knative/serving/issues/12594

**Release Note**

```release-note
Updates net-istio validating webhook to use an objectSelector to reduce unnecessary webhook invocations
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
