### PR TITLE
Removing deprecated serving.knative.dev/release label

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:

--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -22,7 +22,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:

--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -24,7 +24,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -46,7 +45,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:

--- a/config/400-config-istio.yaml
+++ b/config/400-config-istio.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:
   # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.

--- a/config/400-webhook-peer-authentication.yaml
+++ b/config/400-webhook-peer-authentication.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -28,7 +27,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -47,7 +45,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -40,7 +39,6 @@ spec:
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/500-webhook-deployment.yaml
+++ b/config/500-webhook-deployment.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -38,7 +37,6 @@ spec:
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/500-webhook-secret.yaml
+++ b/config/500-webhook-secret.yaml
@@ -21,5 +21,4 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio

--- a/config/500-webhook-service.yaml
+++ b/config/500-webhook-service.yaml
@@ -22,7 +22,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:

--- a/config/600-mutating-webhook.yaml
+++ b/config/600-mutating-webhook.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 webhooks:
 - admissionReviewVersions:

--- a/config/600-validating-webhook.yaml
+++ b/config/600-validating-webhook.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 webhooks:
 - admissionReviewVersions:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -35,8 +35,8 @@ readonly RELEASES
 function build_release() {
   # Update release labels if this is a tagged release
   if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\" and app.kubernetes.io/version: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
+    echo "Tagged release, updating release labels to app.kubernetes.io/version: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
   else
     echo "Untagged release, will NOT update release labels"
     LABEL_YAML_CMD=(cat)

--- a/pkg/reconciler/ingress/config/testdata/config-istio.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-istio.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
 data:
   # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.

--- a/pkg/reconciler/ingress/config/testdata/config-network.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-network.yaml
@@ -21,8 +21,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
-
 data:
   _example: |
     ################################

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -21,14 +21,14 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -43,7 +43,6 @@ metadata:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -18,7 +18,8 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 
 ---
 kind: Role
@@ -27,7 +28,8 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -43,7 +45,8 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -60,7 +63,8 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Previously agreed these labels would be dropped in release v1.4
Follow on to #804 , #861 
See https://github.com/knative/serving/issues/12215 for more details.


```release-note
`serving.knative.dev/release` labels, deprecated in v1.3, have been removed. Please switch over to using `app.kubernetes.io/name: knative-serving` and `app.kuberentes.io/version: devel`.
```
