### PR TITLE
Remove `local-gateway.mesh: "mesh"` option

### DIFF
--- a/config/400-config-istio.yaml
+++ b/config/400-config-istio.yaml
@@ -64,13 +64,6 @@ data:
     # `knative-serving`
     local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.istio-system.svc.cluster.local"
 
-    # DEPRECATED: local-gateway.mesh is deprecated.
-    # See: https://github.com/knative/serving/issues/11523
-    #
-    # To use only Istio service mesh and no knative-local-gateway, replace
-    # all local-gateway.* entries by the following entry.
-    local-gateway.mesh: "mesh"
-
     # If true, knative will use the Istio VirtualService's status to determine
     # endpoint readiness. Otherwise, probe as usual.
     # NOTE: This feature is currently experimental and should not be used in production.

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -148,7 +148,6 @@ func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
 	if len(localGateways) == 0 {
 		localGateways = defaultLocalGateways()
 	}
-	localGateways = removeMeshGateway(localGateways)
 
 	var statusEnabled bool
 	if err := cm.Parse(configMap.Data,
@@ -162,14 +161,4 @@ func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
 		LocalGateways:              localGateways,
 		EnableVirtualServiceStatus: statusEnabled,
 	}, nil
-}
-
-func removeMeshGateway(gateways []Gateway) []Gateway {
-	gws := []Gateway{}
-	for _, g := range gateways {
-		if g.Name != "mesh" {
-			gws = append(gws, g)
-		}
-	}
-	return gws
 }

--- a/pkg/reconciler/ingress/config/istio_test.go
+++ b/pkg/reconciler/ingress/config/istio_test.go
@@ -222,22 +222,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				"local-gateway.custom-namespace.invalid": "_invalid",
 			},
 		},
-	}, {
-		name:    "local gateway configuration with mesh",
-		wantErr: false,
-		wantIstio: &Istio{
-			IngressGateways: defaultIngressGateways(),
-			LocalGateways:   []Gateway{},
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      IstioConfigName,
-			},
-			Data: map[string]string{
-				"local-gateway.mesh": "mesh",
-			},
-		},
 	}}
 
 	for _, tt := range gatewayConfigTests {

--- a/pkg/reconciler/ingress/config/testdata/config-istio.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-istio.yaml
@@ -41,12 +41,10 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # Default Knative Gateway after v0.3. It points to the Istio
-    # standard istio-ingressgateway, instead of a custom one that we
-    # used pre-0.3. The configuration format should be `gateway.
-    # {{gateway_namespace}}.{{gateway_name}}: "{{ingress_name}}.
-    # {{ingress_namespace}}.svc.cluster.local"`. The {{gateway_namespace}}
-    # is optional; when it is omitted, the system will search for
+    # A gateway and Istio service to serve external traffic.
+    # The configuration format should be
+    # `gateway.{{gateway_namespace}}.{{gateway_name}}: "{{ingress_name}}.{{ingress_namespace}}.svc.cluster.local"`.
+    # The {{gateway_namespace}} is optional; when it is omitted, the system will search for
     # the gateway in the serving system namespace `knative-serving`
     gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
 
@@ -66,10 +64,7 @@ data:
     # `knative-serving`
     local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.istio-system.svc.cluster.local"
 
-    # To use only Istio service mesh and no knative-local-gateway, replace
-    # all local-gateway.* entries by the following entry.
-    local-gateway.mesh: "mesh"
-
     # If true, knative will use the Istio VirtualService's status to determine
     # endpoint readiness. Otherwise, probe as usual.
+    # NOTE: This feature is currently experimental and should not be used in production.
     enable-virtualservice-status: "false"


### PR DESCRIPTION
As per https://github.com/knative/serving/issues/11523, this patch removes `local-gateway.mesh: "mesh"`.

Please note that it does not remove `local-gateway.<GATEWAY>: <GATEWAY_SVC>` is still availble.
This patch removes only `mesh` which is a special configuration.


**Release Note**

```release-note
`local-gateway.mesh: "mesh"` option was dropped.
```

/cc @ZhiminXiang @carlisia 