### PR TITLE
Fix net deprecations

### DIFF
--- a/pkg/reconciler/ingress/config/store.go
+++ b/pkg/reconciler/ingress/config/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	network "knative.dev/networking/pkg"
+	"knative.dev/networking/pkg/config"
 	"knative.dev/pkg/configmap"
 )
 
@@ -29,7 +30,7 @@ type cfgKey struct{}
 // +k8s:deepcopy-gen=false
 type Config struct {
 	Istio   *Istio
-	Network *network.Config
+	Network *config.Config
 }
 
 // FromContext fetch config from context.
@@ -63,8 +64,8 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 			"ingress",
 			logger,
 			configmap.Constructors{
-				IstioConfigName:    NewIstioFromConfigMap,
-				network.ConfigName: network.NewConfigFromConfigMap,
+				IstioConfigName:      NewIstioFromConfigMap,
+				config.ConfigMapName: network.NewConfigFromConfigMap,
 			},
 			onAfterStore...,
 		),
@@ -82,6 +83,6 @@ func (s *Store) ToContext(ctx context.Context) context.Context {
 func (s *Store) Load() *Config {
 	return &Config{
 		Istio:   s.UntypedLoad(IstioConfigName).(*Istio).DeepCopy(),
-		Network: s.UntypedLoad(network.ConfigName).(*network.Config).DeepCopy(),
+		Network: s.UntypedLoad(config.ConfigMapName).(*config.Config).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/ingress/config/store_test.go
+++ b/pkg/reconciler/ingress/config/store_test.go
@@ -24,6 +24,7 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 
 	network "knative.dev/networking/pkg"
+	netconfig "knative.dev/networking/pkg/config"
 	. "knative.dev/pkg/configmap/testing"
 )
 
@@ -31,7 +32,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 	store := NewStore(logtesting.TestLogger(t))
 
 	istioConfig := ConfigMapFromTestFile(t, IstioConfigName)
-	networkConfig := ConfigMapFromTestFile(t, network.ConfigName)
+	networkConfig := ConfigMapFromTestFile(t, netconfig.ConfigMapName)
 	store.OnConfigChanged(istioConfig)
 	store.OnConfigChanged(networkConfig)
 	config := FromContext(store.ToContext(context.Background()))
@@ -51,19 +52,19 @@ func TestStoreImmutableConfig(t *testing.T) {
 	store := NewStore(logtesting.TestLogger(t))
 
 	store.OnConfigChanged(ConfigMapFromTestFile(t, IstioConfigName))
-	store.OnConfigChanged(ConfigMapFromTestFile(t, network.ConfigName))
+	store.OnConfigChanged(ConfigMapFromTestFile(t, netconfig.ConfigMapName))
 
 	config := store.Load()
 
 	config.Istio.IngressGateways = []Gateway{{Name: "mutated", ServiceURL: "mutated"}}
-	config.Network.HTTPProtocol = network.HTTPRedirected
+	config.Network.HTTPProtocol = netconfig.HTTPRedirected
 
 	newConfig := store.Load()
 
 	if newConfig.Istio.IngressGateways[0].Name == "mutated" {
 		t.Error("Istio config is not immutable")
 	}
-	if newConfig.Network.HTTPProtocol == network.HTTPRedirected {
+	if newConfig.Network.HTTPProtocol == netconfig.HTTPRedirected {
 		t.Error("Network config is not immuable")
 	}
 }

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -25,11 +25,11 @@ import (
 	gatewayinformer "knative.dev/net-istio/pkg/client/istio/injection/informers/networking/v1alpha3/gateway"
 	virtualserviceinformer "knative.dev/net-istio/pkg/client/istio/injection/informers/networking/v1alpha3/virtualservice"
 	"knative.dev/net-istio/pkg/reconciler/ingress/config"
-	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	ingressinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress"
 	ingressreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/ingress"
+	netconfig "knative.dev/networking/pkg/config"
 	"knative.dev/networking/pkg/status"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
@@ -95,12 +95,12 @@ func newControllerWithOptions(
 		secretLister:         secretInformer.Lister(),
 		svcLister:            serviceInformer.Lister(),
 	}
-	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
+	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, netconfig.IstioIngressClassName, true)
 
-	impl := ingressreconciler.NewImpl(ctx, c, network.IstioIngressClassName, func(impl *controller.Impl) controller.Options {
+	impl := ingressreconciler.NewImpl(ctx, c, netconfig.IstioIngressClassName, func(impl *controller.Impl) controller.Options {
 		configsToResync := []interface{}{
 			&config.Istio{},
-			&network.Config{},
+			&netconfig.Config{},
 		}
 		resyncIngressesOnConfigChange := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
 			impl.FilteredGlobalResync(myFilterFunc, ingressInformer.Informer())

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -37,10 +37,10 @@ import (
 	istioaccessor "knative.dev/net-istio/pkg/reconciler/accessor/istio"
 	"knative.dev/net-istio/pkg/reconciler/ingress/config"
 	"knative.dev/net-istio/pkg/reconciler/ingress/resources"
-	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	ingressreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/ingress"
+	netconfig "knative.dev/networking/pkg/config"
 	"knative.dev/networking/pkg/status"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -312,7 +312,7 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ing *v1alpha1
 	// First, create all needed VirtualServices.
 	kept := sets.NewString()
 	for _, d := range desired {
-		if d.GetAnnotations()[networking.IngressClassAnnotationKey] != network.IstioIngressClassName {
+		if d.GetAnnotations()[networking.IngressClassAnnotationKey] != netconfig.IstioIngressClassName {
 			// We do not create resources that do not have istio ingress class annotation.
 			// As a result, obsoleted resources will be cleaned up.
 			continue

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -63,10 +63,10 @@ import (
 
 	"knative.dev/net-istio/pkg/reconciler/ingress/config"
 	"knative.dev/net-istio/pkg/reconciler/ingress/resources"
-	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	ingressreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/ingress"
+	netconfig "knative.dev/networking/pkg/config"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
@@ -670,7 +670,7 @@ func TestReconcile(t *testing.T) {
 		}
 
 		return ingressreconciler.NewReconciler(ctx, logging.FromContext(ctx), fakenetworkingclient.Get(ctx),
-			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, network.IstioIngressClassName, controller.Options{
+			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, netconfig.IstioIngressClassName, controller.Options{
 				ConfigStore: &testConfigStore{
 					config: ReconcilerTestConfig(),
 				}})
@@ -1205,7 +1205,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		}
 
 		return ingressreconciler.NewReconciler(ctx, logging.FromContext(ctx), fakenetworkingclient.Get(ctx),
-			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, network.IstioIngressClassName, controller.Options{
+			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, netconfig.IstioIngressClassName, controller.Options{
 				ConfigStore: &testConfigStore{
 					// Enable reconciling gateway.
 					config: &config.Config{
@@ -1216,8 +1216,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
 							}},
 						},
-						Network: &network.Config{
-							HTTPProtocol: network.HTTPDisabled,
+						Network: &netconfig.Config{
+							HTTPProtocol: netconfig.HTTPDisabled,
 							AutoTLS:      true,
 						},
 					},
@@ -1303,7 +1303,7 @@ func TestReconcile_DisableStatus(t *testing.T) {
 		config.Istio.EnableVirtualServiceStatus = false
 
 		return ingressreconciler.NewReconciler(ctx, logging.FromContext(ctx), fakenetworkingclient.Get(ctx),
-			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, network.IstioIngressClassName, controller.Options{
+			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, netconfig.IstioIngressClassName, controller.Options{
 				ConfigStore: &testConfigStore{
 					config: ReconcilerTestConfig(),
 				}})
@@ -1455,7 +1455,7 @@ func ReconcilerTestConfig() *config.Config {
 			}},
 			EnableVirtualServiceStatus: true,
 		},
-		Network: &network.Config{
+		Network: &netconfig.Config{
 			AutoTLS: false,
 		},
 	}
@@ -1476,7 +1476,7 @@ func ingressWithStatus(name string, status v1alpha1.IngressStatus) *v1alpha1.Ing
 				resources.RouteLabelKey:          "test-route",
 				resources.RouteNamespaceLabelKey: testNS,
 			},
-			Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			Annotations:     map[string]string{networking.IngressClassAnnotationKey: netconfig.IstioIngressClassName},
 			ResourceVersion: "v1",
 		},
 		Spec: v1alpha1.IngressSpec{
@@ -1599,7 +1599,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 		Data: originGateways,
 	}, {
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      network.ConfigName,
+			Name:      netconfig.ConfigMapName,
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
@@ -1816,7 +1816,7 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	// Test changes in autoTLS of config-network ConfigMap. Ingress should get updated appropriately.
 	networkConfig := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      network.ConfigName,
+			Name:      netconfig.ConfigMapName,
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -31,9 +31,9 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	istiolisters "knative.dev/net-istio/pkg/client/istio/listers/networking/v1alpha3"
-	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/ingress"
+	"knative.dev/networking/pkg/k8s"
 	"knative.dev/networking/pkg/status"
 )
 
@@ -151,7 +151,7 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1alpha3.Gateway) (
 			continue
 		}
 
-		portName, err := network.NameForPortNumber(service, int32(server.Port.Number))
+		portName, err := k8s.NameForPortNumber(service, int32(server.Port.Number))
 		if err != nil {
 			l.logger.Infof("Skipping Server %q because Service %s/%s doesn't contain a port %d", server.Port.Name, service.Namespace, service.Name, server.Port.Number)
 			continue
@@ -168,7 +168,7 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1alpha3.Gateway) (
 			// We can't simply translate from the Service.Spec because Service.Spec.Target.Port
 			// could be either a name or a number.  In the Endpoints spec, all ports are provided
 			// as numbers.
-			portNumber, err := network.PortNumberForName(sub, portName)
+			portNumber, err := k8s.PortNumberForName(sub, portName)
 			if err != nil {
 				l.logger.Infof("Skipping Subset %v because it doesn't contain a port name %q", sub.Addresses, portName)
 				continue

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -33,9 +33,9 @@ import (
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"knative.dev/net-istio/pkg/reconciler/ingress/config"
-	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	netconfig "knative.dev/networking/pkg/config"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeserviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	"knative.dev/pkg/kmeta"
@@ -666,8 +666,8 @@ func TestMakeWildcardGateways(t *testing.T) {
 					ServiceURL: fmt.Sprintf("%s.%s.svc.cluster.local", tc.gatewayService.Name, tc.gatewayService.Namespace),
 				}},
 			},
-			Network: &network.Config{
-				HTTPProtocol: network.HTTPEnabled,
+			Network: &netconfig.Config{
+				HTTPProtocol: netconfig.HTTPEnabled,
 			},
 		})
 		t.Run(tc.name, func(t *testing.T) {
@@ -769,8 +769,8 @@ func TestMakeIngressGateways(t *testing.T) {
 					ServiceURL: fmt.Sprintf("%s.%s.svc.cluster.local", defaultGatewayService.Name, defaultGatewayService.Namespace),
 				}},
 			},
-			Network: &network.Config{
-				HTTPProtocol: network.HTTPEnabled,
+			Network: &netconfig.Config{
+				HTTPProtocol: netconfig.HTTPEnabled,
 			},
 		})
 		t.Run(c.name, func(t *testing.T) {
@@ -942,8 +942,8 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 					ServiceURL: fmt.Sprintf("%s.%s.svc.cluster.local", c.gatewayService.Name, c.gatewayService.Namespace),
 				}},
 			},
-			Network: &network.Config{
-				HTTPProtocol: network.HTTPEnabled,
+			Network: &netconfig.Config{
+				HTTPProtocol: netconfig.HTTPEnabled,
 			},
 		})
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/reconciler/serverlessservice/resources/virtualservice.go
+++ b/pkg/reconciler/serverlessservice/resources/virtualservice.go
@@ -21,8 +21,8 @@ import (
 
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
-	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/networking/pkg/http/header"
 	"knative.dev/pkg/kmeta"
 	pkgnetwork "knative.dev/pkg/network"
 )
@@ -45,7 +45,7 @@ func MakeVirtualService(sks *v1alpha1.ServerlessService) *v1alpha3.VirtualServic
 			Http: []*istiov1alpha3.HTTPRoute{{
 				Match: []*istiov1alpha3.HTTPMatchRequest{{
 					Headers: map[string]*istiov1alpha3.StringMatch{
-						network.PassthroughLoadbalancingHeaderName: {
+						header.PassthroughLoadbalancingKey: {
 							MatchType: &istiov1alpha3.StringMatch_Exact{
 								Exact: "true",
 							},

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -31,9 +31,9 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/net-istio/pkg/reconciler/ingress/config"
 	"knative.dev/net-istio/pkg/reconciler/serverlessservice/resources"
-	network "knative.dev/networking/pkg"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	sksreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice"
+	netconfig "knative.dev/networking/pkg/config"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -196,7 +196,7 @@ func TestReconcile(t *testing.T) {
 				ConfigStore: &testConfigStore{
 					config: &config.Config{
 						Istio: &config.Istio{},
-						Network: &network.Config{
+						Network: &netconfig.Config{
 							EnableMeshPodAddressability: true,
 						},
 					},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- As per title. golangci lint is broken due to latest net api deprecation.
