### PR TITLE
bump kind and k8s versions for kind-e2e test

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,8 +20,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.7
-        - v1.23.5
+        - v1.22.9
+        - v1.23.6
+        - v1.24.0
 
         test-suite:
         - ./test/conformance
@@ -34,14 +35,17 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.22.7
-          kind-version: v0.12.0
-          kind-image-sha: sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
+        - k8s-version: v1.22.9
+          kind-version: v0.14.0
+          kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
 
-        - k8s-version: v1.23.5
-          kind-version: v0.12.0
-          kind-image-sha: sha256:a69c29d3d502635369a5fe92d8e503c09581fcd406ba6598acc5d80ff5ba81b1
+        - k8s-version: v1.23.6
+          kind-version: v0.14.0
+          kind-image-sha: sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
 
+        - k8s-version: v1.24.0
+          kind-version: v0.14.0
+          kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
 
     env:
       GOPATH: ${{ github.workspace }}


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Since we will probably be supporting Kubernetes v1.24 in the next release, and kind v0.13.0+ is required to run Kubernetes v1.24.0+ images, let's go ahead and bump the versions now, so we have a chance to work out any issues before the next release.