### PR TITLE
Add workaround for k8s 1.25

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -22,10 +22,7 @@ jobs:
         k8s-version:
         - v1.23.12
         - v1.24.6
-        # istioctl manifest generates incompatible manifests with 1.25.
-        # See: https://github.com/istio/istio/issues/41220
-        # We need to wait for https://github.com/istio/istio/commit/c5e79d2cc4c303f274dc1f5df004ca7d6c4ff7ee.
-        # - v1.25.2
+        - v1.25.2
 
         test-suite:
         - ./test/conformance
@@ -46,9 +43,9 @@ jobs:
           kind-version: v0.16.0
           kind-image-sha: sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1
 
-            # - k8s-version: v1.25.2
-            #  kind-version: v0.16.0
-            #  kind-image-sha: sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace
+        - k8s-version: v1.25.2
+          kind-version: v0.16.0
+          kind-image-sha: sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace
 
     env:
       GOPATH: ${{ github.workspace }}

--- a/third_party/istio-latest/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/istio.yaml
@@ -8761,7 +8761,7 @@ spec:
     kind: Deployment
     name: istiod
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
@@ -8780,7 +8780,7 @@ spec:
       app: istio-ingressgateway
       istio: ingressgateway
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod

--- a/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
@@ -8761,7 +8761,7 @@ spec:
     kind: Deployment
     name: istiod
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
@@ -8780,7 +8780,7 @@ spec:
       app: istio-ingressgateway
       istio: ingressgateway
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -8761,7 +8761,7 @@ spec:
     kind: Deployment
     name: istiod
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
@@ -8780,7 +8780,7 @@ spec:
       app: istio-ingressgateway
       istio: ingressgateway
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: istiod

--- a/third_party/library.sh
+++ b/third_party/library.sh
@@ -151,6 +151,9 @@ EOF
 
     # Remove documents with no content
     run_yq eval --inplace 'select(. != null)' "${target_dir}/istio.yaml"
+
+    # Workaround until the fix for https://github.com/istio/istio/issues/41220 is released.
+    sed -i "s/policy\/v1beta1/policy\/v1/" "${target_dir}/istio.yaml"
   done
 }
 


### PR DESCRIPTION
Due to an issue in `istioctl manifest generates`, the manifest does not  produce `policy/v1`.

This patch adds the workaround which replaces the version by sed in script.

Fix https://github.com/knative-sandbox/net-istio/issues/993