### PR TITLE
Make the webhook port number configurable

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -81,7 +81,7 @@ func main() {
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
 		ServiceName: "net-istio-webhook",
 		SecretName:  "net-istio-webhook-certs",
-		Port:        8443,
+		Port:        webhook.PortFromEnv(8443),
 	})
 
 	sharedmain.WebhookMainWithContext(

--- a/config/500-webhook-deployment.yaml
+++ b/config/500-webhook-deployment.yaml
@@ -68,6 +68,10 @@ spec:
           value: knative.dev/net-istio
         - name: WEBHOOK_NAME
           value: net-istio-webhook
+        # If you change WEBHOOK_PORT, you will also need to change the
+        # containerPort "https-webhook" to the same value.
+        - name: WEBHOOK_PORT
+          value: "8443"
 
         securityContext:
           runAsNonRoot: true

--- a/config/500-webhook-service.yaml
+++ b/config/500-webhook-service.yaml
@@ -28,12 +28,12 @@ spec:
   # Define metrics and profiling for them to be accessible within service meshes.
   - name: http-metrics
     port: 9090
-    targetPort: 9090
+    targetPort: metrics
   - name: http-profiling
     port: 8008
-    targetPort: 8008
+    targetPort: profiling
   - name: https-webhook
     port: 443
-    targetPort: 8443
+    targetPort: https-webhook
   selector:
     app: net-istio-webhook


### PR DESCRIPTION
Make the webhook port number configurable

Previously the webhook listened on a fixed port, 8443, which can clash
with other services when the webhook is run on the host network in
Kubernetes, which is required when using some CNI implementations,
notably Calico on EKS [1].

Enable configuration of the webhook listen port through the environment
variable WEBHOOK_PORT by using the existing API from the KNative SDK.

[1] https://projectcalico.docs.tigera.io/getting-started/kubernetes/managed-public-cloud/eks#install-eks-with-calico-networking

Signed-off-by: Steve Larkin <steve.larkin@gmail.com>