### PR TITLE
drop setting seccomp profile

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -78,8 +78,6 @@ spec:
           capabilities:
             drop:
               - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/500-webhook-deployment.yaml
+++ b/config/500-webhook-deployment.yaml
@@ -79,8 +79,6 @@ spec:
           capabilities:
             drop:
               - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics


### PR DESCRIPTION
This causes issues on clusters < 1.25 and can break upgrades

Related: https://github.com/knative/serving/issues/13512