### PR TITLE
Ensure that a Gateway name does not exceed 63 length

### DIFF
--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -285,7 +285,16 @@ func GatewayName(accessor kmeta.Accessor, gatewaySvc *corev1.Service) string {
 	if !isDNS1123Label(prefix) {
 		prefix = fmt.Sprint(adler32.Checksum([]byte(prefix)))
 	}
+
 	gatewayServiceKey := fmt.Sprintf("%s/%s", gatewaySvc.Namespace, gatewaySvc.Name)
+	gatewayServiceKeyChecksum := fmt.Sprint(adler32.Checksum([]byte(gatewayServiceKey)))
+
+	// Ensure that the overall gateway name still is a DNS1123 label
+	maxPrefixLength := dns1123LabelMaxLength - len(gatewayServiceKeyChecksum) - 1
+	if len(prefix) > maxPrefixLength {
+		prefix = prefix[0:maxPrefixLength]
+	}
+
 	return fmt.Sprint(prefix+"-", adler32.Checksum([]byte(gatewayServiceKey)))
 }
 

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -1003,3 +1003,24 @@ func TestGatewayName(t *testing.T) {
 		t.Errorf("Unexpected gateway name. want %q, got %q", want, got)
 	}
 }
+
+func TestGatewayNameLongIngressName(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway",
+			Namespace: "istio-system",
+		},
+	}
+	ingress := &v1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "areallyverylongdomainnamethatexcd8923dee789a086a0ac46d3046cbec7",
+			Namespace: "default",
+		},
+	}
+
+	want := fmt.Sprintf("areallyverylongdomainnamethatexcd8923dee789a086a0ac4-%d", adler32.Checksum([]byte("istio-system/gateway")))
+	got := GatewayName(ingress, svc)
+	if got != want {
+		t.Errorf("Unexpected gateway name. want %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
# Changes

I have Knative and Istio together with net-istio running, and I created a domain mapping with a long name. Knative Serving turned this into a KIngress with name `areallyverylongdomainnamethatexcd8923dee789a086a0ac46d3046cbec7`. Based on that, Net-Istio tried to create a gateway name `areallyverylongdomainnamethatexcd8923dee789a086a0ac46d3046cbec7-3797421420` which is [rejected by Istio's validating webhook](https://github.com/istio/istio/blob/1.16.1/pkg/config/validation/validation.go#L463-L465):

```
Message: admission webhook "validation.istio.io" denied the request: configuration is invalid: invalid gateway name: "areallyverylongdomainnamethatexcd8923dee789a086a0ac46d3046cbec7-3797421420"
```

I am changing the logic to shorten the prefix as much as needed.

/kind bug

**Release Note**

```release-note
Domain mappings with long domain names do not fail anymore to get their Ingress ready
```

**Docs**

N/A