### PR TITLE
Ensure wildcard certificate secrets can also track back their source secret

### DIFF
--- a/pkg/reconciler/accessor/core/secret.go
+++ b/pkg/reconciler/accessor/core/secret.go
@@ -59,10 +59,11 @@ func ReconcileSecret(ctx context.Context, owner kmeta.Accessor, desired *corev1.
 		return nil, kaccessor.NewAccessorError(
 			fmt.Errorf("owner: %s with Type %T does not own Secret: %s", owner.GetName(), owner, secret.Name),
 			kaccessor.NotOwnResource)
-	} else if !equality.Semantic.DeepEqual(secret.Data, desired.Data) {
+	} else if !equality.Semantic.DeepEqual(secret.Data, desired.Data) || !equality.Semantic.DeepEqual(secret.Labels, desired.Labels) {
 		// Don't modify the informers copy
 		copy := secret.DeepCopy()
 		copy.Data = desired.Data
+		copy.Labels = desired.Labels
 		secret, err = accessor.GetKubeClient().CoreV1().Secrets(copy.Namespace).Update(ctx, copy, metav1.UpdateOptions{})
 		if err != nil {
 			recorder.Eventf(owner, corev1.EventTypeWarning, "UpdateFailed", "Failed to update Secret %s/%s: %v", desired.Namespace, desired.Name, err)

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -1097,8 +1097,9 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					Name:      targetSecretName,
 					Namespace: "istio-system",
 					Labels: map[string]string{
-						networking.OriginSecretNameLabelKey:      "secret0",
-						networking.OriginSecretNamespaceLabelKey: "knative-serving",
+						"networking.internal.knative.dev/certificate-uid": "",
+						networking.OriginSecretNameLabelKey:               "secret0",
+						networking.OriginSecretNamespaceLabelKey:          "knative-serving",
 					},
 				},
 				// The data is expected to be updated to the right one.

--- a/pkg/reconciler/ingress/resources/secret.go
+++ b/pkg/reconciler/ingress/resources/secret.go
@@ -87,7 +87,7 @@ func MakeWildcardSecrets(ctx context.Context, originWildcardCerts map[string]*co
 				// as the origin namespace
 				continue
 			}
-			secrets = append(secrets, makeSecret(secret, targetWildcardSecretName(secret.Name, secret.Namespace), meta.Namespace, map[string]string{}, nil))
+			secrets = append(secrets, makeSecret(secret, targetWildcardSecretName(secret.Name, secret.Namespace), meta.Namespace, MakeTargetSecretLabels(secret.Name, secret.Namespace), MakeTargetSecretAnnotations(secret.Name)))
 		}
 	}
 	return secrets, nil

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -263,7 +263,11 @@ func TestMakeWildcardSecrets(t *testing.T) {
 				// Expected secret should be in istio-system which is
 				// the ns of Istio gateway service.
 				Namespace: "istio-system",
-				Labels:    map[string]string{"networking.internal.knative.dev/certificate-uid": ""},
+				Labels: map[string]string{
+					"networking.internal.knative.dev/certificate-uid": "",
+					networking.OriginSecretNameLabelKey:               "test-secret",
+					networking.OriginSecretNamespaceLabelKey:          "knative-serving",
+				},
 			},
 			Data: map[string][]byte{
 				"test-data": []byte("abcd"),


### PR DESCRIPTION
# Changes

When recently doing https://github.com/knative-sandbox/net-istio/pull/1043, I was already surprised that a wildcard certificate copy in the Istio system namespace is NOT getting any labels to track back the original secret.

I now verified that this is indeed causing issues:

1. An update of the original secret is not propagated to the copy.
2. The secret copy is never deleted even if it is not needed anymore.

I am therefore setting the same labels and annotation on a wildcard secret in this PR. The main change is in pkg/reconciler/ingress/resources/secret.go.

The purpose of the change in pkg/reconciler/accessor/core/secret.go is to fix all existing secret copies' labels. The test case change in pkg/reconciler/ingress/ingress_test.go is related to this given the missing label is now also updated.

/kind bug

**Release Note**

```release-note
Updates to secrets with wildcard certificate are now properly propagated to the istio-system namespace
```

**Docs**

N/A