### PR TITLE
disable telemetry in e2e tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -16,8 +16,6 @@
 
 source $(dirname $0)/e2e-common.sh
 
-export ENABLE_GKE_TELEMETRY=true
-
 # Script entry point.
 initialize $@  --skip-istio-addon
 


### PR DESCRIPTION
Forgot to undo this in https://github.com/knative-sandbox/net-istio/pull/1078

