### PR TITLE
Fixing golangci-lint issues

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -34,7 +34,7 @@ import (
 	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
 )
 
-func NewConfigValidationController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+func NewConfigValidationController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 	return configmaps.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
@@ -55,7 +55,7 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 }
 
 // NewDefaultingAdmissionController adds default values to the watched types
-func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+func NewDefaultingAdmissionController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 	return defaulting.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.

--- a/pkg/defaults/deployment_defaults.go
+++ b/pkg/defaults/deployment_defaults.go
@@ -57,7 +57,7 @@ var (
 )
 
 // SetDefaults implements apis.Defaultable
-func (r *IstioDeployment) SetDefaults(ctx context.Context) {
+func (r *IstioDeployment) SetDefaults(_ context.Context) {
 	if r.Labels == nil {
 		r.Labels = make(map[string]string)
 	}
@@ -97,6 +97,6 @@ func (r *IstioDeployment) servingName() string {
 }
 
 // Validate returns nil due to no need for validation
-func (r *IstioDeployment) Validate(ctx context.Context) *apis.FieldError {
+func (r *IstioDeployment) Validate(_ context.Context) *apis.FieldError {
 	return nil
 }

--- a/pkg/reconciler/accessor/core/secret.go
+++ b/pkg/reconciler/accessor/core/secret.go
@@ -61,15 +61,15 @@ func ReconcileSecret(ctx context.Context, owner kmeta.Accessor, desired *corev1.
 			kaccessor.NotOwnResource)
 	} else if !equality.Semantic.DeepEqual(secret.Data, desired.Data) || !equality.Semantic.DeepEqual(secret.Labels, desired.Labels) {
 		// Don't modify the informers copy
-		copy := secret.DeepCopy()
-		copy.Data = desired.Data
-		copy.Labels = desired.Labels
-		secret, err = accessor.GetKubeClient().CoreV1().Secrets(copy.Namespace).Update(ctx, copy, metav1.UpdateOptions{})
+		deepCopy := secret.DeepCopy()
+		deepCopy.Data = desired.Data
+		deepCopy.Labels = desired.Labels
+		secret, err = accessor.GetKubeClient().CoreV1().Secrets(deepCopy.Namespace).Update(ctx, deepCopy, metav1.UpdateOptions{})
 		if err != nil {
 			recorder.Eventf(owner, corev1.EventTypeWarning, "UpdateFailed", "Failed to update Secret %s/%s: %v", desired.Namespace, desired.Name, err)
 			return nil, fmt.Errorf("failed to update Secret: %w", err)
 		}
-		recorder.Eventf(owner, corev1.EventTypeNormal, "Updated", "Updated Secret %s/%s", copy.Namespace, copy.Name)
+		recorder.Eventf(owner, corev1.EventTypeNormal, "Updated", "Updated Secret %s/%s", deepCopy.Namespace, deepCopy.Name)
 	}
 	return secret, nil
 }

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -188,7 +188,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 	}
 	gatewayNames[v1alpha1.IngressVisibilityExternalIP].Insert(resources.GetQualifiedGatewayNames(ingressGateways)...)
 
-	vses, err := resources.MakeVirtualServices(ctx, ing, gatewayNames)
+	vses, err := resources.MakeVirtualServices(ing, gatewayNames)
 	if err != nil {
 		return err
 	}
@@ -297,9 +297,9 @@ func (r *Reconciler) reconcileSystemGeneratedGateway(ctx context.Context, desire
 	} else if err != nil {
 		return err
 	} else if !cmp.Equal(existing.Spec.DeepCopy(), desired.Spec.DeepCopy(), protocmp.Transform()) {
-		copy := existing.DeepCopy()
-		copy.Spec = *desired.Spec.DeepCopy()
-		if _, err := r.istioClientSet.NetworkingV1alpha3().Gateways(desired.Namespace).Update(ctx, copy, metav1.UpdateOptions{}); err != nil {
+		deepCopy := existing.DeepCopy()
+		deepCopy.Spec = *desired.Spec.DeepCopy()
+		if _, err := r.istioClientSet.NetworkingV1alpha3().Gateways(desired.Namespace).Update(ctx, deepCopy, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
 	}
@@ -419,9 +419,9 @@ func (r *Reconciler) reconcileGateway(ctx context.Context, ing *v1alpha1.Ingress
 		return nil
 	}
 
-	copy := gateway.DeepCopy()
-	copy = resources.UpdateGateway(copy, desired, existing)
-	if _, err := r.istioClientSet.NetworkingV1alpha3().Gateways(copy.Namespace).Update(ctx, copy, metav1.UpdateOptions{}); err != nil {
+	deepCopy := gateway.DeepCopy()
+	deepCopy = resources.UpdateGateway(deepCopy, desired, existing)
+	if _, err := r.istioClientSet.NetworkingV1alpha3().Gateways(deepCopy.Namespace).Update(ctx, deepCopy, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update Gateway: %w", err)
 	}
 	controller.GetEventRecorder(ctx).Eventf(ing, corev1.EventTypeNormal,

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -309,11 +309,10 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ing("reconcile-failed")), gateways),
+			resources.MakeMeshVirtualService(insertProbe(ing("reconcile-failed")), gateways),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: resources.MakeIngressVirtualService(context.Background(), insertProbe(ing("reconcile-failed")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
+			Object: resources.MakeIngressVirtualService(insertProbe(ing("reconcile-failed")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithStatus("reconcile-failed",
@@ -379,11 +378,10 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: resources.MakeIngressVirtualService(context.Background(), insertProbe(ing("reconcile-virtualservice")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
+			Object: resources.MakeIngressVirtualService(insertProbe(ing("reconcile-virtualservice")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
 		}},
 		WantCreates: []runtime.Object{
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ing("reconcile-virtualservice")), gateways),
+			resources.MakeMeshVirtualService(insertProbe(ing("reconcile-virtualservice")), gateways),
 		},
 		WantDeletes: []clientgotesting.DeleteActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{
@@ -441,10 +439,8 @@ func TestReconcile(t *testing.T) {
 		Key:  "test-ns/ingress-ready",
 		Objects: []runtime.Object{
 			basicReconciledIngress("ingress-ready"),
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ing("ingress-ready")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
-			resources.MakeIngressVirtualService(context.Background(), insertProbe(ing("ingress-ready")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ing("ingress-ready")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
+			resources.MakeIngressVirtualService(insertProbe(ing("ingress-ready")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil)),
 		},
 		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
 		CmpOpts:        defaultCmpOptsList,
@@ -469,26 +465,22 @@ func TestReconcile(t *testing.T) {
 				PublicLoadBalancer:  &v1alpha1.LoadBalancerStatus{Ingress: []v1alpha1.LoadBalancerIngressStatus{{DomainInternal: "test-ingressgateway.istio-system.svc.cluster.local"}}},
 			},
 				[]string{"ingresses.networking.internal.knative.dev"}),
-			meshVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-virtualservice-ready")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+			meshVirtualServiceWithStatus(insertProbe(ing("ingress-virtualservice-ready")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 1, 1),
-			ingressVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-virtualservice-ready")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+				},
+			}, 1, 1),
+			ingressVirtualServiceWithStatus(insertProbe(ing("ingress-virtualservice-ready")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 1, 1),
+				},
+			}, 1, 1),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithStatusAndFinalizers("ingress-virtualservice-ready", v1alpha1.IngressStatus{
@@ -535,26 +527,22 @@ func TestReconcile(t *testing.T) {
 				PublicLoadBalancer:  &v1alpha1.LoadBalancerStatus{Ingress: []v1alpha1.LoadBalancerIngressStatus{{DomainInternal: "test-ingressgateway.istio-system.svc.cluster.local"}}},
 			},
 				[]string{"ingresses.networking.internal.knative.dev"}),
-			meshVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-virtualservice-notready")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+			meshVirtualServiceWithStatus(insertProbe(ing("ingress-virtualservice-notready")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 1, 1),
-			ingressVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-virtualservice-notready")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "False",
-						},
+				},
+			}, 1, 1),
+			ingressVirtualServiceWithStatus(insertProbe(ing("ingress-virtualservice-notready")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "False",
 					},
-				}, 1, 1),
+				},
+			}, 1, 1),
 		},
 		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
 		CmpOpts:        defaultCmpOptsList,
@@ -583,26 +571,22 @@ func TestReconcile(t *testing.T) {
 				PublicLoadBalancer:  &v1alpha1.LoadBalancerStatus{Ingress: []v1alpha1.LoadBalancerIngressStatus{{DomainInternal: "test-ingressgateway.istio-system.svc.cluster.local"}}},
 			},
 				[]string{"ingresses.networking.internal.knative.dev"}),
-			meshVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-virtualservice-stale")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+			meshVirtualServiceWithStatus(insertProbe(ing("ingress-virtualservice-stale")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 2, 2),
-			ingressVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-virtualservice-stale")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+				},
+			}, 2, 2),
+			ingressVirtualServiceWithStatus(insertProbe(ing("ingress-virtualservice-stale")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 2, 1),
+				},
+			}, 2, 1),
 		},
 		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
 		CmpOpts:        defaultCmpOptsList,
@@ -631,26 +615,22 @@ func TestReconcile(t *testing.T) {
 				PublicLoadBalancer:  &v1alpha1.LoadBalancerStatus{Ingress: []v1alpha1.LoadBalancerIngressStatus{{DomainInternal: "test-ingressgateway.istio-system.svc.cluster.local"}}},
 			},
 				[]string{"ingresses.networking.internal.knative.dev"}),
-			meshVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-virtualservice-nostatus")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+			meshVirtualServiceWithStatus(insertProbe(ing("ingress-virtualservice-nostatus")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 1, 0),
-			ingressVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-virtualservice-nostatus")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+				},
+			}, 1, 0),
+			ingressVirtualServiceWithStatus(insertProbe(ing("ingress-virtualservice-nostatus")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 1, 0),
+				},
+			}, 1, 0),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithStatusAndFinalizers("ingress-virtualservice-nostatus", v1alpha1.IngressStatus{
@@ -705,9 +685,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			gateway(perIngressGatewayName, testNS, []*istiov1alpha3.Server{ingressTLSServer, ingressHTTPServer},
 				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)),
-				makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
@@ -768,9 +747,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				[]*istiov1alpha3.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)),
-				makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: gateway(perIngressGatewayName, testNS,
@@ -835,10 +813,9 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)),
-				makeGatewayMap([]string{"istio-system/" + resources.WildcardGatewayName(wildcardCert.Name, ingressService.Namespace, ingressService.Name),
-					"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"istio-system/" + resources.WildcardGatewayName(wildcardCert.Name, ingressService.Namespace, ingressService.Name),
+				"test-ns/" + perIngressGatewayName}, nil)),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
@@ -996,9 +973,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), ingressGateway),
-			resources.MakeIngressVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))),
-				makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), ingressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
 
 			// The secret copy under istio-system.
 			targetSecret("istio-system", targetSecretName, map[string]string{
@@ -1087,9 +1063,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), ingressGateway),
-			resources.MakeIngressVirtualService(context.Background(), insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))),
-				makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), ingressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: &corev1.Secret{
@@ -1157,7 +1132,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			originSecret("istio-system", "secret0"),
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeMeshVirtualService(context.Background(), insertProbe(ingressWithTLSClusterLocal("reconciling-ingress", ingressTLS)), ingressGateway),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLSClusterLocal("reconciling-ingress", ingressTLS)), ingressGateway),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatusClusterLocal("reconciling-ingress",
@@ -1271,26 +1246,22 @@ func TestReconcile_DisableStatus(t *testing.T) {
 				PublicLoadBalancer:  &v1alpha1.LoadBalancerStatus{Ingress: []v1alpha1.LoadBalancerIngressStatus{{DomainInternal: "test-ingressgateway.istio-system.svc.cluster.local"}}},
 			},
 				[]string{"ingresses.networking.internal.knative.dev"}),
-			meshVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-vs-status-disabled")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+			meshVirtualServiceWithStatus(insertProbe(ing("ingress-vs-status-disabled")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 1, 1),
-			ingressVirtualServiceWithStatus(context.Background(), insertProbe(ing("ingress-vs-status-disabled")),
-				makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil),
-				&istiov1alpha1.IstioStatus{
-					Conditions: []*istiov1alpha1.IstioCondition{
-						{
-							Type:   "Reconciled",
-							Status: "True",
-						},
+				},
+			}, 1, 1),
+			ingressVirtualServiceWithStatus(insertProbe(ing("ingress-vs-status-disabled")), makeGatewayMap([]string{"knative-testing/knative-test-gateway", "knative-testing/" + config.KnativeIngressGateway}, nil), &istiov1alpha1.IstioStatus{
+				Conditions: []*istiov1alpha1.IstioCondition{
+					{
+						Type:   "Reconciled",
+						Status: "True",
 					},
-				}, 1, 1),
+				},
+			}, 1, 1),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithStatusAndFinalizers("ingress-vs-status-disabled", v1alpha1.IngressStatus{
@@ -1575,8 +1546,8 @@ func ingressWithTLSAndStatusClusterLocal(name string, tls []v1alpha1.IngressTLS,
 	return ci
 }
 
-func meshVirtualServiceWithStatus(ctx context.Context, ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String, status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1alpha3.VirtualService {
-	vs := resources.MakeMeshVirtualService(ctx, ing, gateways)
+func meshVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String, status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1alpha3.VirtualService {
+	vs := resources.MakeMeshVirtualService(ing, gateways)
 	vs.Status = *status.DeepCopy()
 	vs.ObjectMeta.Generation = generation
 	vs.Status.ObservedGeneration = observedGeneration
@@ -1584,8 +1555,8 @@ func meshVirtualServiceWithStatus(ctx context.Context, ing *v1alpha1.Ingress, ga
 	return vs
 }
 
-func ingressVirtualServiceWithStatus(ctx context.Context, ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String, status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1alpha3.VirtualService {
-	vs := resources.MakeIngressVirtualService(ctx, ing, gateways)
+func ingressVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String, status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1alpha3.VirtualService {
+	vs := resources.MakeIngressVirtualService(ing, gateways)
 	vs.Status = *status.DeepCopy()
 	vs.ObjectMeta.Generation = generation
 	vs.Status.ObservedGeneration = observedGeneration

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -1549,7 +1549,7 @@ func (l *fakeGatewayLister) Gateways(namespace string) istiolisters.GatewayNames
 	}
 }
 
-func (l *fakeGatewayLister) List(selector labels.Selector) ([]*v1alpha3.Gateway, error) {
+func (l *fakeGatewayLister) List(_ labels.Selector) ([]*v1alpha3.Gateway, error) {
 	log.Panic("not implemented")
 	return nil, nil
 }
@@ -1559,7 +1559,7 @@ type fakeGatewayNamespaceLister struct {
 	fails    bool
 }
 
-func (l *fakeGatewayNamespaceLister) List(selector labels.Selector) ([]*v1alpha3.Gateway, error) {
+func (l *fakeGatewayNamespaceLister) List(_ labels.Selector) ([]*v1alpha3.Gateway, error) {
 	log.Panic("not implemented")
 	return nil, nil
 }
@@ -1583,12 +1583,12 @@ type fakeEndpointsLister struct {
 	fails       bool
 }
 
-func (l *fakeEndpointsLister) List(selector labels.Selector) ([]*v1.Endpoints, error) {
+func (l *fakeEndpointsLister) List(_ labels.Selector) ([]*v1.Endpoints, error) {
 	log.Panic("not implemented")
 	return nil, nil
 }
 
-func (l *fakeEndpointsLister) Endpoints(namespace string) corev1listers.EndpointsNamespaceLister {
+func (l *fakeEndpointsLister) Endpoints(_ string) corev1listers.EndpointsNamespaceLister {
 	return l
 }
 
@@ -1622,12 +1622,12 @@ func (l *fakeServiceLister) List(selector labels.Selector) ([]*v1.Service, error
 	return results, nil
 }
 
-func (l *fakeServiceLister) Services(namespace string) corev1listers.ServiceNamespaceLister {
+func (l *fakeServiceLister) Services(_ string) corev1listers.ServiceNamespaceLister {
 	log.Panic("not implemented")
 	return nil
 }
 
-func (l *fakeServiceLister) GetPodServices(pod *v1.Pod) ([]*v1.Service, error) {
+func (l *fakeServiceLister) GetPodServices(_ *v1.Pod) ([]*v1.Service, error) {
 	log.Panic("not implemented")
 	return nil, nil
 }

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -196,7 +195,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			vss, err := MakeVirtualServices(context.Background(), tc.ci, tc.gateways)
+			vss, err := MakeVirtualServices(tc.ci, tc.gateways)
 			if err != nil {
 				t.Fatal("MakeVirtualServices failed:", err)
 			}
@@ -317,7 +316,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectGateways(t *testing.T) {
 			}}},
 	}
 	expected := []string{"mesh"}
-	gateways := MakeMeshVirtualService(context.Background(), ci, defaultGateways).Spec.Gateways
+	gateways := MakeMeshVirtualService(ci, defaultGateways).Spec.Gateways
 	if diff := cmp.Diff(expected, gateways); diff != "" {
 		t.Error("Unexpected gateways (-want +got):", diff)
 	}
@@ -344,7 +343,7 @@ func TestMakeMeshVirtualServiceSpecCorrectHosts(t *testing.T) {
 		expectedHosts: sets.NewString("test-route.test-ns.svc.cluster.local"),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			vs := MakeMeshVirtualService(context.Background(), &defaultIngress, tc.gateways)
+			vs := MakeMeshVirtualService(&defaultIngress, tc.gateways)
 			vsHosts := sets.NewString(vs.Spec.Hosts...)
 			if !vsHosts.Equal(tc.expectedHosts) {
 				t.Errorf("Unexpected hosts want %v; got %v", tc.expectedHosts, vsHosts)
@@ -443,7 +442,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 	}}
 
-	routes := MakeMeshVirtualService(context.Background(), ci, defaultGateways).Spec.Http
+	routes := MakeMeshVirtualService(ci, defaultGateways).Spec.Http
 	if diff := cmp.Diff(expected, routes, defaultVSCmpOpts); diff != "" {
 		t.Error("Unexpected routes (-want +got):", diff)
 	}
@@ -456,7 +455,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectGateways(t *testing.T) {
 		ci.Spec.Rules[idx].Visibility = v1alpha1.IngressVisibilityExternalIP
 	}
 	expected := []string{"knative-testing/gateway-one", "knative-testing/gateway-two"}
-	gateways := MakeIngressVirtualService(context.Background(), ci, makeGatewayMap([]string{"knative-testing/gateway-one", "knative-testing/gateway-two"}, nil)).Spec.Gateways
+	gateways := MakeIngressVirtualService(ci, makeGatewayMap([]string{"knative-testing/gateway-one", "knative-testing/gateway-two"}, nil)).Spec.Gateways
 	if diff := cmp.Diff(expected, gateways); diff != "" {
 		t.Error("Unexpected gateways (-want +got):", diff)
 	}
@@ -585,7 +584,7 @@ func TestMakeIngressVirtualServiceSpec_CorrectRoutes(t *testing.T) {
 		},
 	}}
 
-	routes := MakeIngressVirtualService(context.Background(), ci, makeGatewayMap([]string{"gateway.public"}, []string{"gateway.private"})).Spec.Http
+	routes := MakeIngressVirtualService(ci, makeGatewayMap([]string{"gateway.public"}, []string{"gateway.private"})).Spec.Http
 	if diff := cmp.Diff(expected, routes, defaultVSCmpOpts); diff != "" {
 		t.Error("Unexpected routes (-want +got):", diff)
 	}

--- a/test/e2e/clients.go
+++ b/test/e2e/clients.go
@@ -38,7 +38,7 @@ type Clients struct {
 
 // NewClientsFromConfig instantiates and returns several clientsets required for making request to the
 // Knative Serving cluster specified by the rest Config. Clients can make requests within namespace.
-func NewClientsFromConfig(cfg *rest.Config, namespace string) (*Clients, error) {
+func NewClientsFromConfig(cfg *rest.Config) (*Clients, error) {
 	// We poll, so set our limits high.
 	cfg.QPS = 100
 	cfg.Burst = 200

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -23,7 +23,6 @@ import (
 	// https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	"knative.dev/networking/test"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 )
@@ -40,7 +39,7 @@ func Setup(t testing.TB) *Clients {
 		t.Fatal("couldn't get REST config:", err)
 	}
 
-	clients, err := NewClientsFromConfig(cfg, test.ServingNamespace)
+	clients, err := NewClientsFromConfig(cfg)
 	if err != nil {
 		t.Fatal("Couldn't initialize clients", "error", err.Error())
 	}


### PR DESCRIPTION
# Changes
- :broom: fixing golangci-lint issues
- :broom: removing unused parameters or setting `_` where necessary because of interfaces

/kind cleanup

