### PR TITLE
Bump k8s version on github action

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -30,18 +30,6 @@ jobs:
         istio-version:
         - latest
 
-        # Map between K8s and KinD versions.
-        # This is attempting to make it a bit clearer what's being tested.
-        # See: https://github.com/kubernetes-sigs/kind/releases
-        include:
-        - k8s-version: v1.24.7
-          kind-version: v0.17.0
-          kind-image-sha: sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
-
-        - k8s-version: v1.25.3
-          kind-version: v0.17.0
-          kind-image-sha: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
-
     env:
       GOPATH: ${{ github.workspace }}
       KO_DOCKER_REPO: kind.local

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -57,19 +57,6 @@ jobs:
       with:
         path: ./src/knative.dev/net-istio
 
-    - name: Install KinD
-      run: |
-        set -x
-
-        # Disable swap otherwise memory enforcement doesn't work
-        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600009955324200
-        sudo swapoff -a
-        sudo rm -f /swapfile
-
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${{ matrix.kind-version }}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
-
     - name: Create KinD Cluster
       uses: chainguard-dev/actions/setup-kind@main
       id: kind

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.24.7
-        - v1.25.3
+        - v1.25.x
+        - v1.26.x
 
         test-suite:
         - ./test/conformance
@@ -83,38 +83,12 @@ jobs:
         sudo mv kind /usr/local/bin
 
     - name: Create KinD Cluster
-      run: |
-        set -x
-
-        # KinD configuration.
-        cat > kind.yaml <<EOF
-        apiVersion: kind.x-k8s.io/v1alpha4
-        kind: Cluster
-        nodes:
-        - role: control-plane
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-        - role: worker
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-
-        # This is needed in order to
-        # (1) support projected volumes with service account tokens. See
-        #     https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
-        # (2) use a random cluster suffix
-        kubeadmConfigPatches:
-          - |
-            kind: ClusterConfiguration
-            metadata:
-              name: config
-            apiServer:
-              extraArgs:
-                "service-account-issuer": "kubernetes.default.svc"
-                "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
-            networking:
-              dnsDomain: "${CLUSTER_SUFFIX}"
-        EOF
-
-        # Create a cluster!
-        kind create cluster --config kind.yaml
+      uses: chainguard-dev/actions/setup-kind@main
+      id: kind
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+        kind-worker-count: 1
+        cluster-suffix: "${CLUSTER_SUFFIX}"
 
     - name: Install Knative net-istio
       run: |


### PR DESCRIPTION
This patch bumps k8s version on CI and changes to use `chainguard-dev/actions/setup-kind@main` for setup.