### PR TITLE
Check all host names of a certificate in isWildcardSecret

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -101,8 +101,8 @@ var (
 )
 
 var (
-	nonWildcardCert, _ = resources.GenerateCertificate("host-1.example.com", "secret0", "istio-system")
-	wildcardCert, _    = resources.GenerateCertificate("*.example.com", "secret0", "istio-system")
+	nonWildcardCert, _ = resources.GenerateCertificate([]string{"host-1.example.com"}, "secret0", "istio-system")
+	wildcardCert, _    = resources.GenerateCertificate([]string{"*.example.com"}, "secret0", "istio-system")
 	selector           = map[string]string{
 		"istio": "ingress",
 	}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -56,7 +56,7 @@ var secret = corev1.Secret{
 
 var secretGVK = schema.GroupVersionKind{Version: "v1", Kind: "Secret"}
 
-var wildcardSecret, _ = GenerateCertificate("*.example.com", "secret0", system.Namespace())
+var wildcardSecret, _ = GenerateCertificate([]string{"*.example.com"}, "secret0", system.Namespace())
 
 var wildcardSecrets = map[string]*corev1.Secret{
 	fmt.Sprintf("%s/secret0", system.Namespace()): wildcardSecret,

--- a/pkg/reconciler/ingress/resources/secret.go
+++ b/pkg/reconciler/ingress/resources/secret.go
@@ -203,7 +203,18 @@ func isWildcardSecret(secret *corev1.Secret) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return isWildcardHost(hosts[0])
+
+	for _, host := range hosts {
+		isWildcard, err := isWildcardHost(host)
+		if err != nil {
+			return false, err
+		}
+		if isWildcard {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func isWildcardHost(domain string) (bool, error) {

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -59,8 +59,9 @@ var (
 		},
 	}
 
-	wildcardCert, _    = GenerateCertificate("*.example.com", "wildcard", "")
-	nonWildcardCert, _ = GenerateCertificate("test.example.com", "nonWildcard", "")
+	wildcardCert, _    = GenerateCertificate([]string{"*.example.com"}, "wildcard", "")
+	wildcardCert2, _   = GenerateCertificate([]string{"example.com", "*.example.com"}, "wildcard", "")
+	nonWildcardCert, _ = GenerateCertificate([]string{"test.example.com"}, "nonWildcard", "")
 )
 
 func TestGetSecrets(t *testing.T) {
@@ -301,13 +302,15 @@ func TestCategorizeSecrets(t *testing.T) {
 		name: "work correctly",
 		secrets: map[string]*corev1.Secret{
 			"wildcard":    wildcardCert,
+			"wildcard2":   wildcardCert2,
 			"nonwildcard": nonWildcardCert,
 		},
 		wantNonWildcard: map[string]*corev1.Secret{
 			"nonwildcard": nonWildcardCert,
 		},
 		wantWildcard: map[string]*corev1.Secret{
-			"wildcard": wildcardCert,
+			"wildcard":  wildcardCert,
+			"wildcard2": wildcardCert2,
 		},
 	}, {
 		name: "invalid secret",

--- a/pkg/reconciler/ingress/resources/util.go
+++ b/pkg/reconciler/ingress/resources/util.go
@@ -51,7 +51,7 @@ const (
 	RouteNamespaceLabelKey = ServingGroupName + "/routeNamespace"
 )
 
-func GenerateCertificate(host string, secretName string, namespace string) (*corev1.Secret, error) {
+func GenerateCertificate(hosts []string, secretName string, namespace string) (*corev1.Secret, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate private key: %w", err)
@@ -79,10 +79,12 @@ func GenerateCertificate(host string, secretName string, namespace string) (*cor
 		BasicConstraintsValid: true,
 	}
 
-	if ip := net.ParseIP(host); ip != nil {
-		template.IPAddresses = append(template.IPAddresses, ip)
-	} else {
-		template.DNSNames = append(template.DNSNames, host)
+	for _, host := range hosts {
+		if ip := net.ParseIP(host); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, host)
+		}
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)


### PR DESCRIPTION
# Changes

This pull request changes the implementation of isWildcardSecret to check all host names in the certificate instead of only the first one. We often use certificates with two host names, something like `*.example.com` and `example.com`. If the host names are in that order, then the function correctly returned `true`. If the first host name is not wildcard, then it returned false. Subsequently, no wildcard gateway was created.

/kind bug

**Release Note**

```release-note
Certificates with multiple hosts where a non-first-entry is a wildcard host are now correctly detected as wildcard secrets
```