### PR TITLE
Drop NodePort from kind manifests

### DIFF
--- a/third_party/istio-latest/istio-kind-ambient.yaml
+++ b/third_party/istio-latest/istio-kind-ambient.yaml
@@ -28,7 +28,6 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false
-        type: NodePort
 
   components:
     ingressGateways:

--- a/third_party/istio-latest/istio-kind-ambient/istio.yaml
+++ b/third_party/istio-latest/istio-kind-ambient/istio.yaml
@@ -10076,7 +10076,7 @@ metadata:
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: IngressGateways
 spec:
-  type: NodePort
+  type: LoadBalancer
   selector:
     app: istio-ingressgateway
     istio: ingressgateway

--- a/third_party/istio-latest/istio-kind-no-mesh.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh.yaml
@@ -27,7 +27,6 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false
-        type: NodePort
 
   meshConfig:
     defaultConfig:

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -9920,7 +9920,7 @@ metadata:
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: IngressGateways
 spec:
-  type: NodePort
+  type: LoadBalancer
   selector:
     app: istio-ingressgateway
     istio: ingressgateway


### PR DESCRIPTION
As per title, this patch drops NodePort from kind manifests which is used by github action.