### PR TITLE
Drop PeerAuthentication for domainmapping-webhook

### DIFF
--- a/config/400-webhook-peer-authentication.yaml
+++ b/config/400-webhook-peer-authentication.yaml
@@ -21,24 +21,6 @@ spec:
 apiVersion: "security.istio.io/v1beta1"
 kind: "PeerAuthentication"
 metadata:
-  name: "domainmapping-webhook"
-  namespace: "knative-serving"
-  labels:
-    app.kubernetes.io/component: net-istio
-    app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: devel
-    networking.knative.dev/ingress-provider: istio
-spec:
-  selector:
-    matchLabels:
-      app: domainmapping-webhook
-  portLevelMtls:
-    "8443":
-      mode: PERMISSIVE
----
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
-metadata:
   name: "net-istio-webhook"
   namespace: "knative-serving"
   labels:


### PR DESCRIPTION
As per title, it was removed since https://github.com/knative/serving/commit/fc166ac8b459a73116ca5535e168aba2d97a2626