### PR TITLE
chore: Migrate to sets.Set[string] when possible

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -48,7 +48,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	istiov1alpha1 "istio.io/api/meta/v1alpha1"
 	istiov1beta1 "istio.io/api/networking/v1beta1"
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
 
@@ -1254,24 +1253,6 @@ func ingressWithTLSAndStatusClusterLocal(name string, tls []v1alpha1.IngressTLS,
 	ci := ingressWithTLSClusterLocal(name, tls)
 	ci.Status = status
 	return ci
-}
-
-func meshVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.Set[string], status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1beta1.VirtualService {
-	vs := resources.MakeMeshVirtualService(ing, gateways)
-	vs.Status = *status.DeepCopy()
-	vs.ObjectMeta.Generation = generation
-	vs.Status.ObservedGeneration = observedGeneration
-
-	return vs
-}
-
-func ingressVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.Set[string], status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1beta1.VirtualService {
-	vs := resources.MakeIngressVirtualService(ing, gateways)
-	vs.Status = *status.DeepCopy()
-	vs.ObjectMeta.Generation = generation
-	vs.Status.ObservedGeneration = observedGeneration
-
-	return vs
 }
 
 func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -140,11 +140,11 @@ var (
 		"gateway." + config.KnativeIngressGateway: newDomainInternal,
 		"gateway.knative-test-gateway":            originDomainInternal,
 	}
-	ingressGateway = map[v1alpha1.IngressVisibility]sets.String{
-		v1alpha1.IngressVisibilityExternalIP: sets.NewString(config.KnativeIngressGateway),
+	ingressGateway = map[v1alpha1.IngressVisibility]sets.Set[string]{
+		v1alpha1.IngressVisibilityExternalIP: sets.New(config.KnativeIngressGateway),
 	}
-	gateways = map[v1alpha1.IngressVisibility]sets.String{
-		v1alpha1.IngressVisibilityExternalIP: sets.NewString("knative-test-gateway", config.KnativeIngressGateway),
+	gateways = map[v1alpha1.IngressVisibility]sets.Set[string]{
+		v1alpha1.IngressVisibilityExternalIP: sets.New("knative-test-gateway", config.KnativeIngressGateway),
 	}
 	perIngressGatewayName = resources.GatewayName(ingressWithTLS("reconciling-ingress", ingressTLS), ingressService)
 )
@@ -1256,7 +1256,7 @@ func ingressWithTLSAndStatusClusterLocal(name string, tls []v1alpha1.IngressTLS,
 	return ci
 }
 
-func meshVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String, status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1beta1.VirtualService {
+func meshVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.Set[string], status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1beta1.VirtualService {
 	vs := resources.MakeMeshVirtualService(ing, gateways)
 	vs.Status = *status.DeepCopy()
 	vs.ObjectMeta.Generation = generation
@@ -1265,7 +1265,7 @@ func meshVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.I
 	return vs
 }
 
-func ingressVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.String, status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1beta1.VirtualService {
+func ingressVirtualServiceWithStatus(ing *v1alpha1.Ingress, gateways map[v1alpha1.IngressVisibility]sets.Set[string], status *istiov1alpha1.IstioStatus, generation int64, observedGeneration int64) *v1beta1.VirtualService {
 	vs := resources.MakeIngressVirtualService(ing, gateways)
 	vs.Status = *status.DeepCopy()
 	vs.ObjectMeta.Generation = generation
@@ -1536,10 +1536,10 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	}
 }
 
-func makeGatewayMap(publicGateways []string, privateGateways []string) map[v1alpha1.IngressVisibility]sets.String {
-	return map[v1alpha1.IngressVisibility]sets.String{
-		v1alpha1.IngressVisibilityExternalIP:   sets.NewString(publicGateways...),
-		v1alpha1.IngressVisibilityClusterLocal: sets.NewString(privateGateways...),
+func makeGatewayMap(publicGateways []string, privateGateways []string) map[v1alpha1.IngressVisibility]sets.Set[string] {
+	return map[v1alpha1.IngressVisibility]sets.Set[string]{
+		v1alpha1.IngressVisibilityExternalIP:   sets.New(publicGateways...),
+		v1alpha1.IngressVisibilityClusterLocal: sets.New(privateGateways...),
 	}
 }
 

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -60,7 +60,7 @@ type gatewayPodTargetLister struct {
 
 func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1alpha1.Ingress) ([]status.ProbeTarget, error) {
 	results := []status.ProbeTarget{}
-	hostsByGateway := ingress.HostsPerVisibility(ing, qualifiedGatewayNamesFromContext(ctx))
+	hostsByGateway := ingress.HostsPerVisibility(ing, convertVisibilityMap(qualifiedGatewayNamesFromContext(ctx)))
 	gatewayNames := make([]string, 0, len(hostsByGateway))
 	for gatewayName := range hostsByGateway {
 		gatewayNames = append(gatewayNames, gatewayName)
@@ -129,7 +129,7 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1beta1.Gateway) ([
 		return nil, fmt.Errorf("failed to get Endpoints: %w", err)
 	}
 
-	seen := sets.NewString()
+	seen := sets.New[string]()
 	targets := []status.ProbeTarget{}
 	for _, server := range gateway.Spec.Servers {
 		tURL := &url.URL{}
@@ -186,4 +186,12 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1beta1.Gateway) ([
 		}
 	}
 	return targets, nil
+}
+
+// Remove me when ingress.HostsPerVisibility uses sets.Set[string]
+func convertVisibilityMap(input map[v1alpha1.IngressVisibility]sets.Set[string]) map[v1alpha1.IngressVisibility]sets.String {
+	return map[v1alpha1.IngressVisibility]sets.String{
+		v1alpha1.IngressVisibilityExternalIP:   sets.NewString(sets.List(input[v1alpha1.IngressVisibilityExternalIP])...),
+		v1alpha1.IngressVisibilityClusterLocal: sets.NewString(sets.List(input[v1alpha1.IngressVisibilityClusterLocal])...),
+	}
 }

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -189,6 +189,7 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1beta1.Gateway) ([
 }
 
 // Remove me when ingress.HostsPerVisibility uses sets.Set[string]
+// nolint: staticcheck
 func convertVisibilityMap(input map[v1alpha1.IngressVisibility]sets.Set[string]) map[v1alpha1.IngressVisibility]sets.String {
 	return map[v1alpha1.IngressVisibility]sets.String{
 		v1alpha1.IngressVisibilityExternalIP:   sets.NewString(sets.List(input[v1alpha1.IngressVisibilityExternalIP])...),

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -398,7 +398,7 @@ func GetIngressGatewaySvcNameNamespaces(ctx context.Context) ([]metav1.ObjectMet
 
 // UpdateGateway replaces the existing servers with the wanted servers.
 func UpdateGateway(gateway *v1beta1.Gateway, want []*istiov1beta1.Server, existing []*istiov1beta1.Server) *v1beta1.Gateway {
-	existingServers := sets.String{}
+	existingServers := sets.New[string]()
 	for i := range existing {
 		existingServers.Insert(existing[i].Port.Name)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- :broom: Migrate `sets.String` to `sets.Set[string]` when possible, `sets.String` being deprecated
- Not every place could have been changed, some dependencies (internal to knative, external to this repo) are still using `sets.String`

/kind cleanup

This chnages is motivated by the linter complaining about that
