### PR TITLE
Add opt-in VirtualService informer label filtering

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -28,5 +28,6 @@ import (
 
 func main() {
 	ctx := informerfiltering.GetContextWithFilteringLabelSelector(signals.NewContext())
+	ctx = informerfiltering.GetContextWithVSFilteringLabelSelector(ctx)
 	sharedmain.MainWithContext(ctx, "net-istio-controller", ingress.NewController, serverlessservice.NewController)
 }

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -64,6 +64,8 @@ spec:
           value: config-observability
         - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
           value: "false"
+        - name: ENABLE_VS_INFORMER_FILTERING_BY_LABEL
+          value: "false" # Default: disabled for backward compatibility
 
         # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
         - name: METRICS_DOMAIN

--- a/pkg/reconciler/informerfiltering/util.go
+++ b/pkg/reconciler/informerfiltering/util.go
@@ -35,11 +35,7 @@ const (
 // when list by informers in this component. If not set or set to false no filtering is applied and instead informers
 // will get any secret available in the cluster which may lead to mem issues in large clusters.
 func ShouldFilterByCertificateUID() bool {
-	if enable := os.Getenv(EnableSecretInformerFilteringByCertUIDEnv); enable != "" {
-		b, _ := strconv.ParseBool(enable)
-		return b
-	}
-	return false
+	return shouldEnableFromEnv(EnableSecretInformerFilteringByCertUIDEnv)
 }
 
 // GetContextWithFilteringLabelSelector returns the passed context with the proper label key selector added to it.
@@ -53,14 +49,7 @@ func GetContextWithFilteringLabelSelector(ctx context.Context) context.Context {
 // ShouldFilterVSByLabel allows opting into VirtualService informer filtering by label selector.
 // When the env var is unset or invalid, filtering is disabled (false).
 func ShouldFilterVSByLabel() bool {
-	if enable := os.Getenv(EnableVSInformerFilteringByLabelEnv); enable != "" {
-		b, err := strconv.ParseBool(enable)
-		if err != nil {
-			return false
-		}
-		return b
-	}
-	return false
+	return shouldEnableFromEnv(EnableVSInformerFilteringByLabelEnv)
 }
 
 // GetContextWithVSFilteringLabelSelector returns the passed context with the proper label key selector added to it.
@@ -69,4 +58,15 @@ func GetContextWithVSFilteringLabelSelector(ctx context.Context) context.Context
 		return istiofilteredFactory.WithSelectors(ctx, networking.IngressLabelKey)
 	}
 	return istiofilteredFactory.WithSelectors(ctx, "") // Allow all
+}
+
+func shouldEnableFromEnv(key string) bool {
+	if enable := os.Getenv(key); enable != "" {
+		b, err := strconv.ParseBool(enable)
+		if err != nil {
+			return false
+		}
+		return b
+	}
+	return false
 }

--- a/pkg/reconciler/informerfiltering/util_test.go
+++ b/pkg/reconciler/informerfiltering/util_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informerfiltering
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	istiofilteredFactory "knative.dev/net-istio/pkg/client/istio/injection/informers/factory/filtered"
+	"knative.dev/networking/pkg/apis/networking"
+)
+
+func TestShouldFilterVSByLabelUnset(t *testing.T) {
+	unsetEnv(t, EnableVSInformerFilteringByLabelEnv)
+
+	if got := ShouldFilterVSByLabel(); got {
+		t.Fatalf("ShouldFilterVSByLabel() = %v, want false when env var is unset", got)
+	}
+}
+
+func TestShouldFilterVSByLabelParse(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{{
+		name:  "true",
+		value: "true",
+		want:  true,
+	}, {
+		name:  "false",
+		value: "false",
+		want:  false,
+	}, {
+		name:  "one",
+		value: "1",
+		want:  true,
+	}, {
+		name:  "zero",
+		value: "0",
+		want:  false,
+	}, {
+		name:  "invalid",
+		value: "notabool",
+		want:  false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnableVSInformerFilteringByLabelEnv, tt.value)
+			if got := ShouldFilterVSByLabel(); got != tt.want {
+				t.Fatalf("ShouldFilterVSByLabel() = %v, want %v for value %q", got, tt.want, tt.value)
+			}
+		})
+	}
+}
+
+func TestGetContextWithVSFilteringLabelSelector(t *testing.T) {
+	t.Setenv(EnableVSInformerFilteringByLabelEnv, "true")
+	ctx := GetContextWithVSFilteringLabelSelector(context.Background())
+	selectors := selectorsFromContext(t, ctx)
+	if len(selectors) != 1 || selectors[0] != networking.IngressLabelKey {
+		t.Fatalf("selectors = %v, want [%q]", selectors, networking.IngressLabelKey)
+	}
+
+	t.Setenv(EnableVSInformerFilteringByLabelEnv, "false")
+	ctx = GetContextWithVSFilteringLabelSelector(context.Background())
+	selectors = selectorsFromContext(t, ctx)
+	if len(selectors) != 1 || selectors[0] != "" {
+		t.Fatalf("selectors = %v, want [\"\"]", selectors)
+	}
+}
+
+func selectorsFromContext(t *testing.T, ctx context.Context) []string {
+	t.Helper()
+	untyped := ctx.Value(istiofilteredFactory.LabelKey{})
+	if untyped == nil {
+		t.Fatal("expected label selectors in context, got nil")
+	}
+	selectors, ok := untyped.([]string)
+	if !ok {
+		t.Fatalf("expected []string selectors, got %T", untyped)
+	}
+	return selectors
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	value, ok := os.LookupEnv(key)
+	_ = os.Unsetenv(key)
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv(key, value)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}

--- a/pkg/reconciler/informerfiltering/util_test.go
+++ b/pkg/reconciler/informerfiltering/util_test.go
@@ -33,7 +33,7 @@ func TestShouldFilterVSByLabelUnset(t *testing.T) {
 	}
 }
 
-func TestShouldFilterVSByLabelParse(t *testing.T) {
+func TestShouldEnableFromEnv(t *testing.T) {
 	tests := []struct {
 		name  string
 		value string
@@ -62,9 +62,68 @@ func TestShouldFilterVSByLabelParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			const key = "ENABLE_TEST_FLAG"
+			t.Setenv(key, tt.value)
+			if got := shouldEnableFromEnv(key); got != tt.want {
+				t.Fatalf("shouldEnableFromEnv() = %v, want %v for value %q", got, tt.want, tt.value)
+			}
+		})
+	}
+}
+
+func TestShouldFilterVSByLabelParse(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{{
+		name:  "true",
+		value: "true",
+		want:  true,
+	}, {
+		name:  "false",
+		value: "false",
+		want:  false,
+	}, {
+		name:  "invalid",
+		value: "notabool",
+		want:  false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(EnableVSInformerFilteringByLabelEnv, tt.value)
 			if got := ShouldFilterVSByLabel(); got != tt.want {
 				t.Fatalf("ShouldFilterVSByLabel() = %v, want %v for value %q", got, tt.want, tt.value)
+			}
+		})
+	}
+}
+
+func TestShouldFilterByCertificateUIDParse(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{{
+		name:  "true",
+		value: "true",
+		want:  true,
+	}, {
+		name:  "false",
+		value: "false",
+		want:  false,
+	}, {
+		name:  "invalid",
+		value: "notabool",
+		want:  false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnableSecretInformerFilteringByCertUIDEnv, tt.value)
+			if got := ShouldFilterByCertificateUID(); got != tt.want {
+				t.Fatalf("ShouldFilterByCertificateUID() = %v, want %v for value %q", got, tt.want, tt.value)
 			}
 		})
 	}
@@ -106,8 +165,8 @@ func unsetEnv(t *testing.T, key string) {
 	t.Cleanup(func() {
 		if ok {
 			_ = os.Setenv(key, value)
-		} else {
-			_ = os.Unsetenv(key)
+			return
 		}
+		_ = os.Unsetenv(key)
 	})
 }

--- a/pkg/reconciler/serverlessservice/resources/virtualservice.go
+++ b/pkg/reconciler/serverlessservice/resources/virtualservice.go
@@ -21,6 +21,7 @@ import (
 
 	istiov1beta1 "istio.io/api/networking/v1beta1"
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
+	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/http/header"
 	"knative.dev/pkg/kmeta"
@@ -38,6 +39,7 @@ func MakeVirtualService(sks *v1alpha1.ServerlessService) *v1beta1.VirtualService
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       sks.Namespace,
+			Labels:          map[string]string{networking.IngressLabelKey: sks.Name},
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(sks)},
 		},
 		Spec: istiov1beta1.VirtualService{

--- a/pkg/reconciler/serverlessservice/resources/virtualservice_test.go
+++ b/pkg/reconciler/serverlessservice/resources/virtualservice_test.go
@@ -24,6 +24,7 @@ import (
 	istiov1beta1 "istio.io/api/networking/v1beta1"
 	istiov1beta1clientset "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/http/header"
 	"knative.dev/pkg/kmeta"
@@ -56,6 +57,7 @@ func TestMakeVirtualService(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            testSvcName,
 			Namespace:       testNamespace,
+			Labels:          map[string]string{networking.IngressLabelKey: testSksName},
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(sks)},
 		},
 		Spec: istiov1beta1.VirtualService{


### PR DESCRIPTION
## Summary
- add opt-in VirtualService informer filtering by `networking.knative.dev/ingress` label
- wire filtered VS informers into ingress and serverlessservice controllers
- label SKS-created VirtualServices for filtering
- fallback to direct API get when lister misses an existing VS (e.g. filtered cache)
- add unit tests for VS filtering util and AlreadyExists fallback

## Upgrade Notes
- when filtering is enabled, preexisting unlabeled VS may be hidden from cache; the reconcile path now falls back to API `Get` on `AlreadyExists`, updates labels, and brings them into the filtered cache on subsequent resyncs

## Testing
- go test ./...
