### PR TITLE
Add `enable-gateways` config option to support mesh-only mode

### DIFF
--- a/config/202-gateway.yaml
+++ b/config/202-gateway.yaml
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 # This is the shared Gateway for all Knative routes to use.
+#
+# In mesh-only mode (external-gateways: "[]" and local-gateways: "[]" in
+# config-istio), this resource is not referenced or reconciled by the
+# controller. It can be safely omitted from mesh-only deployments.
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:

--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -15,6 +15,10 @@
 # A cluster local gateway to allow pods outside of the mesh to access
 # Services and Routes not exposing through an ingress.  If the users
 # do have a service mesh setup, this isn't required.
+#
+# In mesh-only mode (external-gateways: "[]" and local-gateways: "[]" in
+# config-istio), this resource is not referenced or reconciled by the
+# controller. It can be safely omitted from mesh-only deployments.
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:

--- a/config/400-config-istio.yaml
+++ b/config/400-config-istio.yaml
@@ -62,6 +62,15 @@ data:
     # If labelSelector is specified, the external gateway will be used by the knative service with matching labels.
     # See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more details about labelSelector.
     # Only one external gateway can be specified without a selector. It will act as the default external gateway.
+    #
+    # To use mesh-only mode (no external ingress gateways), set to an empty list:
+    #   external-gateways: "[]"
+    # Both external-gateways and local-gateways must be set to "[]" for mesh-only mode.
+    # Mesh-only mode requires an Istio sidecar on the net-istio controller pod.
+    #
+    # IMPORTANT: Do not add or remove gateways after Knative Services have been
+    # created. Existing services will not be updated to reflect the new gateway
+    # configuration and may become unreachable.
     external-gateways: |
       - name: knative-ingress-gateway
         namespace: knative-serving
@@ -105,6 +114,14 @@ data:
     # If labelSelector is specified, the local gateway will be used by the knative service with matching labels.
     # See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more details about labelSelector.
     # Only one local gateway can be specified without a selector. It will act as the default local gateway.
+    #
+    # To use mesh-only mode (no local gateways), set to an empty list:
+    #   local-gateways: "[]"
+    # Both external-gateways and local-gateways must be set to "[]" for mesh-only mode.
+    #
+    # IMPORTANT: Do not add or remove gateways after Knative Services have been
+    # created. Existing services will not be updated to reflect the new gateway
+    # configuration and may become unreachable.
     local-gateways: |
       - name: knative-local-gateway
         namespace: knative-serving

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -29,9 +29,14 @@ spec:
   template:
     metadata:
       labels:
-        # This must be outside of the mesh to probe the gateways.
-        # NOTE: this is allowed here and not elsewhere because
-        # this is the Istio controller, and so it may be Istio-aware.
+        # In gateway mode (default), the controller must be outside of the mesh
+        # to probe the gateway pods directly.
+        #
+        # For mesh-only mode (external-gateways: "[]", local-gateways: "[]"),
+        # set this to "true" so the controller gets a sidecar. The sidecar is
+        # required for mesh probes to route through the mesh VirtualService.
+        # Without it, mesh probing is skipped and ingress is marked ready
+        # immediately after VirtualService reconciliation.
         sidecar.istio.io/inject: "false"
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
@@ -102,5 +107,7 @@ spec:
         - name: probes
           containerPort: 8080
 
-# Unlike other controllers, this doesn't need a Service defined for metrics and
-# profiling because it opts out of the mesh (see annotation above).
+# In the default gateway mode, this controller doesn't need a Service defined
+# for metrics and profiling because it opts out of the mesh (see annotation
+# above). If running in mesh-only mode with sidecar.istio.io/inject: "true",
+# you may need to add a Service for metrics and profiling endpoints.

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -58,7 +58,6 @@ const (
 
 	// IstioNamespace is the namespace containing Istio
 	IstioNamespace = "istio-system"
-
 )
 
 func defaultIngressGateways() []Gateway {
@@ -122,7 +121,6 @@ type Istio struct {
 
 	// LocalGateways specifies the gateway urls for public & private Ingress.
 	LocalGateways []Gateway
-
 }
 
 func (i Istio) Validate() error {
@@ -206,10 +204,10 @@ func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
 }
 
 func isNewFormatDefined(configMap *corev1.ConfigMap) bool {
-	gateway := configMap.Data[externalGatewaysKey]
-	localGateway := configMap.Data[localGatewaysKey]
+	_, hasGateway := configMap.Data[externalGatewaysKey]
+	_, hasLocalGateway := configMap.Data[localGatewaysKey]
 
-	return gateway != "" || localGateway != ""
+	return hasGateway || hasLocalGateway
 }
 
 func isOldFormatDefined(configMap *corev1.ConfigMap) bool {
@@ -227,9 +225,9 @@ func parseNewFormat(configMap *corev1.ConfigMap) (*Istio, error) {
 
 	gatewaysStr := configMap.Data[externalGatewaysKey]
 
-	// An empty string (or absent key) means use defaults.
+	// An empty/whitespace-only string (or absent key) means use defaults.
 	// An explicit non-empty value like "[]" means no gateways of that type.
-	if gatewaysStr != "" {
+	if strings.TrimSpace(gatewaysStr) != "" {
 		gateways, err := parseNewFormatGateways(gatewaysStr)
 		if err != nil {
 			return ret, fmt.Errorf("failed to parse %q gateways: %w", externalGatewaysKey, err)
@@ -242,7 +240,7 @@ func parseNewFormat(configMap *corev1.ConfigMap) (*Istio, error) {
 
 	localGatewaysStr := configMap.Data[localGatewaysKey]
 
-	if localGatewaysStr != "" {
+	if strings.TrimSpace(localGatewaysStr) != "" {
 		localGateways, err := parseNewFormatGateways(localGatewaysStr)
 		if err != nil {
 			return ret, fmt.Errorf("failed to parse %q gateways: %w", localGatewaysKey, err)

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -58,6 +58,9 @@ const (
 
 	// IstioNamespace is the namespace containing Istio
 	IstioNamespace = "istio-system"
+
+	// enableGatewaysKey is the configmap key to enable or disable gateway creation.
+	enableGatewaysKey = "enable-gateways"
 )
 
 func defaultIngressGateways() []Gateway {
@@ -121,6 +124,11 @@ type Istio struct {
 
 	// LocalGateways specifies the gateway urls for public & private Ingress.
 	LocalGateways []Gateway
+
+	// EnableGateways specifies whether gateway creation and usage is enabled.
+	// When false, only mesh VirtualServices are created and probing targets
+	// destination service pods directly. Defaults to true.
+	EnableGateways bool
 }
 
 func (i Istio) Validate() error {
@@ -165,8 +173,20 @@ func defaultGateways(gtws []Gateway) []Gateway {
 
 // NewIstioFromConfigMap creates an Istio config from the supplied ConfigMap
 func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
-	ret := &Istio{}
+	ret := &Istio{
+		EnableGateways: true, // default to true for backward compatibility
+	}
 	var err error
+
+	// Parse the enable-gateways setting.
+	if val, ok := configMap.Data[enableGatewaysKey]; ok {
+		ret.EnableGateways = strings.EqualFold(val, "true")
+	}
+
+	// When gateways are disabled, skip gateway configuration entirely.
+	if !ret.EnableGateways {
+		return ret, nil
+	}
 
 	oldFormatDefined := isOldFormatDefined(configMap)
 	newFormatDefined := isNewFormatDefined(configMap)
@@ -182,8 +202,10 @@ func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse configmap: %w", err)
 		}
+		ret.EnableGateways = true
 	case oldFormatDefined:
 		ret = parseOldFormat(configMap)
+		ret.EnableGateways = true
 	default:
 		defaultValues(ret)
 	}

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -59,8 +59,6 @@ const (
 	// IstioNamespace is the namespace containing Istio
 	IstioNamespace = "istio-system"
 
-	// enableGatewaysKey is the configmap key to enable or disable gateway creation.
-	enableGatewaysKey = "enable-gateways"
 )
 
 func defaultIngressGateways() []Gateway {
@@ -125,10 +123,6 @@ type Istio struct {
 	// LocalGateways specifies the gateway urls for public & private Ingress.
 	LocalGateways []Gateway
 
-	// EnableGateways specifies whether gateway creation and usage is enabled.
-	// When false, only mesh VirtualServices are created and probing targets
-	// destination service pods directly. Defaults to true.
-	EnableGateways bool
 }
 
 func (i Istio) Validate() error {
@@ -171,22 +165,17 @@ func defaultGateways(gtws []Gateway) []Gateway {
 	return ret
 }
 
+// GatewaysEnabled returns true if any ingress or local gateways are configured.
+// When both gateway lists are empty (e.g. via external-gateways: "[]" and
+// local-gateways: "[]"), this returns false, indicating mesh-only mode.
+func (i Istio) GatewaysEnabled() bool {
+	return len(i.IngressGateways) > 0 || len(i.LocalGateways) > 0
+}
+
 // NewIstioFromConfigMap creates an Istio config from the supplied ConfigMap
 func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
-	ret := &Istio{
-		EnableGateways: true, // default to true for backward compatibility
-	}
+	ret := &Istio{}
 	var err error
-
-	// Parse the enable-gateways setting.
-	if val, ok := configMap.Data[enableGatewaysKey]; ok {
-		ret.EnableGateways = strings.EqualFold(val, "true")
-	}
-
-	// When gateways are disabled, skip gateway configuration entirely.
-	if !ret.EnableGateways {
-		return ret, nil
-	}
 
 	oldFormatDefined := isOldFormatDefined(configMap)
 	newFormatDefined := isNewFormatDefined(configMap)
@@ -202,10 +191,8 @@ func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse configmap: %w", err)
 		}
-		ret.EnableGateways = true
 	case oldFormatDefined:
 		ret = parseOldFormat(configMap)
-		ret.EnableGateways = true
 	default:
 		defaultValues(ret)
 	}
@@ -260,13 +247,22 @@ func parseNewFormat(configMap *corev1.ConfigMap) (*Istio, error) {
 		ret.LocalGateways = localGateways
 	}
 
-	defaultValues(ret)
+	// Only apply defaults for gateway types that were not explicitly defined.
+	// An explicit empty list (e.g. "[]") means no gateways of that type.
+	if !hasGateway {
+		ret.IngressGateways = defaultIngressGateways()
+	}
+	if !hasLocalGateway {
+		ret.LocalGateways = defaultLocalGateways()
+	}
 
-	if len(ret.DefaultExternalGateways()) != 1 {
+	// Only validate the "exactly one default" constraint for gateway types
+	// that have entries. Empty lists are valid (mesh-only mode).
+	if len(ret.IngressGateways) > 0 && len(ret.DefaultExternalGateways()) != 1 {
 		return ret, fmt.Errorf("exactly one external gateway with no selector can be defined, here: %v", ret.DefaultExternalGateways())
 	}
 
-	if len(ret.DefaultLocalGateways()) != 1 {
+	if len(ret.LocalGateways) > 0 && len(ret.DefaultLocalGateways()) != 1 {
 		return ret, fmt.Errorf("exactly one local gateway with no selector can be defined, here: %v", ret.DefaultLocalGateways())
 	}
 

--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -206,10 +206,10 @@ func NewIstioFromConfigMap(configMap *corev1.ConfigMap) (*Istio, error) {
 }
 
 func isNewFormatDefined(configMap *corev1.ConfigMap) bool {
-	_, hasGateway := configMap.Data[externalGatewaysKey]
-	_, hasLocalGateway := configMap.Data[localGatewaysKey]
+	gateway := configMap.Data[externalGatewaysKey]
+	localGateway := configMap.Data[localGatewaysKey]
 
-	return hasGateway || hasLocalGateway
+	return gateway != "" || localGateway != ""
 }
 
 func isOldFormatDefined(configMap *corev1.ConfigMap) bool {
@@ -225,34 +225,31 @@ func isOldFormatDefined(configMap *corev1.ConfigMap) bool {
 func parseNewFormat(configMap *corev1.ConfigMap) (*Istio, error) {
 	ret := &Istio{}
 
-	gatewaysStr, hasGateway := configMap.Data[externalGatewaysKey]
+	gatewaysStr := configMap.Data[externalGatewaysKey]
 
-	if hasGateway {
+	// An empty string (or absent key) means use defaults.
+	// An explicit non-empty value like "[]" means no gateways of that type.
+	if gatewaysStr != "" {
 		gateways, err := parseNewFormatGateways(gatewaysStr)
 		if err != nil {
 			return ret, fmt.Errorf("failed to parse %q gateways: %w", externalGatewaysKey, err)
 		}
 
 		ret.IngressGateways = gateways
+	} else {
+		ret.IngressGateways = defaultIngressGateways()
 	}
 
-	localGatewaysStr, hasLocalGateway := configMap.Data[localGatewaysKey]
+	localGatewaysStr := configMap.Data[localGatewaysKey]
 
-	if hasLocalGateway {
+	if localGatewaysStr != "" {
 		localGateways, err := parseNewFormatGateways(localGatewaysStr)
 		if err != nil {
 			return ret, fmt.Errorf("failed to parse %q gateways: %w", localGatewaysKey, err)
 		}
 
 		ret.LocalGateways = localGateways
-	}
-
-	// Only apply defaults for gateway types that were not explicitly defined.
-	// An explicit empty list (e.g. "[]") means no gateways of that type.
-	if !hasGateway {
-		ret.IngressGateways = defaultIngressGateways()
-	}
-	if !hasLocalGateway {
+	} else {
 		ret.LocalGateways = defaultLocalGateways()
 	}
 

--- a/pkg/reconciler/ingress/config/istio_test.go
+++ b/pkg/reconciler/ingress/config/istio_test.go
@@ -64,7 +64,6 @@ func TestGatewayConfiguration(t *testing.T) {
 		wantIstio: &Istio{
 			IngressGateways: defaultIngressGateways(),
 			LocalGateways:   defaultLocalGateways(),
-			EnableGateways:  true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -93,7 +92,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local",
 			}},
 			LocalGateways:  defaultLocalGateways(),
-			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -113,7 +111,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local.",
 			}},
 			LocalGateways:  defaultLocalGateways(),
-			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -133,7 +130,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local",
 			}},
 			LocalGateways:  defaultLocalGateways(),
-			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -165,7 +161,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "knative-ingress-backroad",
 				ServiceURL: "istio-ingressbackroad.istio-system.svc.cluster.local",
 			}},
-			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -197,7 +192,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "custom-local-gateway",
 				ServiceURL: "istio-ingressbackroad.istio-system.svc.cluster.local",
 			}},
-			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -233,7 +227,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "gateway2",
 				ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 			}},
-			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -401,8 +394,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 			}},
 			IngressGateways: defaultIngressGateways(),
-			EnableGateways:  true,
-		},
+			},
 	}, {
 		name: "new format - missing local gateway configuration",
 		config: &corev1.ConfigMap{
@@ -424,7 +416,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				ServiceURL: "istio-ingressbackroad.istio-system.svc.cluster.local",
 			}},
 			LocalGateways:  defaultLocalGateways(),
-			EnableGateways: true,
 		},
 	}, {
 		name: "new format - missing default gateway",
@@ -520,7 +511,6 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "gateway2",
 				ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 			}},
-			EnableGateways: true,
 		},
 	}, {
 		name: "local gateway with selector",
@@ -576,7 +566,6 @@ func TestGatewayConfiguration(t *testing.T) {
 					ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 				},
 			},
-			EnableGateways: true,
 		},
 	}, {
 		name: "new format - invalid label selector",
@@ -601,11 +590,10 @@ func TestGatewayConfiguration(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
-		name: "enable-gateways explicitly true",
+		name: "new format - both gateways explicitly empty for mesh-only mode",
 		wantIstio: &Istio{
-			IngressGateways: defaultIngressGateways(),
-			LocalGateways:   defaultLocalGateways(),
-			EnableGateways:  true,
+			IngressGateways: []Gateway{},
+			LocalGateways:   []Gateway{},
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -613,13 +601,15 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:      IstioConfigName,
 			},
 			Data: map[string]string{
-				"enable-gateways": "true",
+				"external-gateways": "[]",
+				"local-gateways":    "[]",
 			},
 		},
 	}, {
-		name: "enable-gateways explicitly false",
+		name: "new format - only external gateways explicitly empty",
 		wantIstio: &Istio{
-			EnableGateways: false,
+			IngressGateways: []Gateway{},
+			LocalGateways:   defaultLocalGateways(),
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -627,20 +617,22 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:      IstioConfigName,
 			},
 			Data: map[string]string{
-				"enable-gateways": "false",
+				"external-gateways": "[]",
 			},
 		},
 	}, {
-		name: "enable-gateways defaults to true when not set",
+		name: "new format - only local gateways explicitly empty",
 		wantIstio: &Istio{
 			IngressGateways: defaultIngressGateways(),
-			LocalGateways:   defaultLocalGateways(),
-			EnableGateways:  true,
+			LocalGateways:   []Gateway{},
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.Namespace(),
 				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				"local-gateways": "[]",
 			},
 		},
 	}}

--- a/pkg/reconciler/ingress/config/istio_test.go
+++ b/pkg/reconciler/ingress/config/istio_test.go
@@ -91,7 +91,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "knative-ingress-freeway",
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local",
 			}},
-			LocalGateways:  defaultLocalGateways(),
+			LocalGateways: defaultLocalGateways(),
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -110,7 +110,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "knative-ingress-freeway",
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local.",
 			}},
-			LocalGateways:  defaultLocalGateways(),
+			LocalGateways: defaultLocalGateways(),
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -129,7 +129,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "custom-gateway",
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local",
 			}},
-			LocalGateways:  defaultLocalGateways(),
+			LocalGateways: defaultLocalGateways(),
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -394,7 +394,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 			}},
 			IngressGateways: defaultIngressGateways(),
-			},
+		},
 	}, {
 		name: "new format - missing local gateway configuration",
 		config: &corev1.ConfigMap{
@@ -415,7 +415,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "gateway1",
 				ServiceURL: "istio-ingressbackroad.istio-system.svc.cluster.local",
 			}},
-			LocalGateways:  defaultLocalGateways(),
+			LocalGateways: defaultLocalGateways(),
 		},
 	}, {
 		name: "new format - missing default gateway",

--- a/pkg/reconciler/ingress/config/istio_test.go
+++ b/pkg/reconciler/ingress/config/istio_test.go
@@ -64,6 +64,7 @@ func TestGatewayConfiguration(t *testing.T) {
 		wantIstio: &Istio{
 			IngressGateways: defaultIngressGateways(),
 			LocalGateways:   defaultLocalGateways(),
+			EnableGateways:  true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -91,7 +92,8 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "knative-ingress-freeway",
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local",
 			}},
-			LocalGateways: defaultLocalGateways(),
+			LocalGateways:  defaultLocalGateways(),
+			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -110,7 +112,8 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "knative-ingress-freeway",
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local.",
 			}},
-			LocalGateways: defaultLocalGateways(),
+			LocalGateways:  defaultLocalGateways(),
+			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -129,7 +132,8 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "custom-gateway",
 				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local",
 			}},
-			LocalGateways: defaultLocalGateways(),
+			LocalGateways:  defaultLocalGateways(),
+			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -161,6 +165,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "knative-ingress-backroad",
 				ServiceURL: "istio-ingressbackroad.istio-system.svc.cluster.local",
 			}},
+			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -192,6 +197,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "custom-local-gateway",
 				ServiceURL: "istio-ingressbackroad.istio-system.svc.cluster.local",
 			}},
+			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -227,6 +233,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "gateway2",
 				ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 			}},
+			EnableGateways: true,
 		},
 		config: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -394,6 +401,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 			}},
 			IngressGateways: defaultIngressGateways(),
+			EnableGateways:  true,
 		},
 	}, {
 		name: "new format - missing local gateway configuration",
@@ -415,7 +423,8 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "gateway1",
 				ServiceURL: "istio-ingressbackroad.istio-system.svc.cluster.local",
 			}},
-			LocalGateways: defaultLocalGateways(),
+			LocalGateways:  defaultLocalGateways(),
+			EnableGateways: true,
 		},
 	}, {
 		name: "new format - missing default gateway",
@@ -511,6 +520,7 @@ func TestGatewayConfiguration(t *testing.T) {
 				Name:       "gateway2",
 				ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 			}},
+			EnableGateways: true,
 		},
 	}, {
 		name: "local gateway with selector",
@@ -566,6 +576,7 @@ func TestGatewayConfiguration(t *testing.T) {
 					ServiceURL: "istio-local-gateway.istio-system.svc.cluster.local",
 				},
 			},
+			EnableGateways: true,
 		},
 	}, {
 		name: "new format - invalid label selector",
@@ -589,6 +600,49 @@ func TestGatewayConfiguration(t *testing.T) {
 			},
 		},
 		wantErr: true,
+	}, {
+		name: "enable-gateways explicitly true",
+		wantIstio: &Istio{
+			IngressGateways: defaultIngressGateways(),
+			LocalGateways:   defaultLocalGateways(),
+			EnableGateways:  true,
+		},
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				"enable-gateways": "true",
+			},
+		},
+	}, {
+		name: "enable-gateways explicitly false",
+		wantIstio: &Istio{
+			EnableGateways: false,
+		},
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				"enable-gateways": "false",
+			},
+		},
+	}, {
+		name: "enable-gateways defaults to true when not set",
+		wantIstio: &Istio{
+			IngressGateways: defaultIngressGateways(),
+			LocalGateways:   defaultLocalGateways(),
+			EnableGateways:  true,
+		},
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+		},
 	}}
 
 	for _, tt := range gatewayConfigTests {

--- a/pkg/reconciler/ingress/config/testdata/config-istio.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-istio.yaml
@@ -68,9 +68,3 @@ data:
     # endpoint readiness. Otherwise, probe as usual.
     # NOTE: This feature is currently experimental and should not be used in production.
     enable-virtualservice-status: "false"
-
-    # To run in mesh-only mode (service-to-service traffic without external
-    # ingress gateways), set both gateway lists to empty:
-    #   external-gateways: "[]"
-    #   local-gateways: "[]"
-    # This disables gateway creation and probes destination service pods directly.

--- a/pkg/reconciler/ingress/config/testdata/config-istio.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-istio.yaml
@@ -69,9 +69,8 @@ data:
     # NOTE: This feature is currently experimental and should not be used in production.
     enable-virtualservice-status: "false"
 
-    # If false, disables Istio Gateway creation and usage. Only mesh
-    # VirtualServices will be created, and probing will target destination
-    # service pods directly. Use this when running Knative for mesh-only
-    # (service-to-service) traffic without external ingress gateways.
-    # Defaults to true.
-    enable-gateways: "true"
+    # To run in mesh-only mode (service-to-service traffic without external
+    # ingress gateways), set both gateway lists to empty:
+    #   external-gateways: "[]"
+    #   local-gateways: "[]"
+    # This disables gateway creation and probes destination service pods directly.

--- a/pkg/reconciler/ingress/config/testdata/config-istio.yaml
+++ b/pkg/reconciler/ingress/config/testdata/config-istio.yaml
@@ -68,3 +68,10 @@ data:
     # endpoint readiness. Otherwise, probe as usual.
     # NOTE: This feature is currently experimental and should not be used in production.
     enable-virtualservice-status: "false"
+
+    # If false, disables Istio Gateway creation and usage. Only mesh
+    # VirtualServices will be created, and probing will target destination
+    # service pods directly. Use this when running Knative for mesh-only
+    # (service-to-service) traffic without external ingress gateways.
+    # Defaults to true.
+    enable-gateways: "true"

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -112,7 +112,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 	cfg := config.FromContext(ctx)
 
 	// When gateways are disabled, take a simplified mesh-only path.
-	if !cfg.Istio.EnableGateways {
+	if !cfg.Istio.GatewaysEnabled() {
 		return r.reconcileMeshOnlyIngress(ctx, ing)
 	}
 
@@ -449,7 +449,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, ing *v1alpha1.Ingress) pk
 	logger := logging.FromContext(ctx)
 	istiocfg := config.FromContext(ctx).Istio
 
-	if istiocfg.EnableGateways {
+	if istiocfg.GatewaysEnabled() {
 		logger.Info("Cleaning up Gateway Servers")
 		for _, gws := range [][]config.Gateway{istiocfg.IngressGateways, istiocfg.LocalGateways} {
 			for _, gw := range gws {

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -109,6 +109,13 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 	ing.Status.InitializeConditions()
 	logger.Infof("Reconciling ingress: %#v", ing)
 
+	cfg := config.FromContext(ctx)
+
+	// When gateways are disabled, take a simplified mesh-only path.
+	if !cfg.Istio.EnableGateways {
+		return r.reconcileMeshOnlyIngress(ctx, ing)
+	}
+
 	defaultGateways, err := resources.GatewaysFromContext(ctx, ing)
 	if err != nil {
 		return err
@@ -170,7 +177,6 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 		gatewayNames[v1alpha1.IngressVisibilityExternalIP].Insert(resources.GetQualifiedGatewayNames(desiredWildcardGateways)...)
 	}
 
-	cfg := config.FromContext(ctx)
 	clusterLocalIngressGateways := []*v1beta1.Gateway{}
 	if cfg.Network.ClusterLocalDomainTLS == netconfig.EncryptionEnabled && shouldReconcileClusterLocalDomainTLS(ing) {
 		originSecrets, err := resources.GetSecrets(ing, v1alpha1.IngressVisibilityClusterLocal, r.secretLister)
@@ -273,6 +279,55 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 
 	// TODO(zhiminx): Mark Route status to indicate that Gateway is configured.
 	logger.Info("Ingress successfully synced")
+	return nil
+}
+
+// reconcileMeshOnlyIngress handles Ingress reconciliation when gateways are
+// disabled. It only creates mesh VirtualServices and probes destination
+// services directly.
+func (r *Reconciler) reconcileMeshOnlyIngress(ctx context.Context, ing *v1alpha1.Ingress) error {
+	logger := logging.FromContext(ctx)
+	logger.Info("Gateways disabled, reconciling mesh-only ingress")
+
+	// Create only mesh VirtualServices with empty gateway names.
+	emptyGateways := map[v1alpha1.IngressVisibility]sets.Set[string]{
+		v1alpha1.IngressVisibilityClusterLocal: sets.New[string](),
+		v1alpha1.IngressVisibilityExternalIP:   sets.New[string](),
+	}
+
+	vses, err := resources.MakeVirtualServices(ing, emptyGateways)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Creating/Updating mesh VirtualServices")
+	if err := r.reconcileVirtualServices(ctx, ing, vses); err != nil {
+		ing.Status.MarkLoadBalancerFailed(virtualServiceNotReconciled, err.Error())
+		return err
+	}
+
+	ing.Status.MarkNetworkConfigured()
+
+	var ready bool
+	if ing.IsReady() {
+		logger.Debug("Kingress is ready, skipping probe.")
+		ready = true
+	} else {
+		readyStatus, err := r.statusManager.IsReady(ctx, ing)
+		if err != nil {
+			return fmt.Errorf("failed to probe Ingress %s/%s: %w", ing.GetNamespace(), ing.GetName(), err)
+		}
+		ready = readyStatus
+	}
+
+	if ready {
+		meshOnlyLbs := []v1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}}
+		ing.Status.MarkLoadBalancerReady(meshOnlyLbs, meshOnlyLbs)
+	} else {
+		ing.Status.MarkLoadBalancerNotReady()
+	}
+
+	logger.Info("Mesh-only ingress successfully synced")
 	return nil
 }
 
@@ -393,12 +448,15 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ing *v1alpha1
 func (r *Reconciler) FinalizeKind(ctx context.Context, ing *v1alpha1.Ingress) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	istiocfg := config.FromContext(ctx).Istio
-	logger.Info("Cleaning up Gateway Servers")
-	for _, gws := range [][]config.Gateway{istiocfg.IngressGateways, istiocfg.LocalGateways} {
-		for _, gw := range gws {
-			err := r.reconcileIngressServers(ctx, ing, gw, []*istiov1beta1.Server{})
-			if err != nil && !apierrs.IsNotFound(err) {
-				return err
+
+	if istiocfg.EnableGateways {
+		logger.Info("Cleaning up Gateway Servers")
+		for _, gws := range [][]config.Gateway{istiocfg.IngressGateways, istiocfg.LocalGateways} {
+			for _, gw := range gws {
+				err := r.reconcileIngressServers(ctx, ing, gw, []*istiov1beta1.Server{})
+				if err != nil && !apierrs.IsNotFound(err) {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -283,11 +283,16 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 }
 
 // reconcileMeshOnlyIngress handles Ingress reconciliation when gateways are
-// disabled. It only creates mesh VirtualServices and probes destination
-// services directly.
+// disabled. It creates mesh VirtualServices and probes the top-level service
+// hostname via the controller's sidecar to verify mesh routing.
+//
+// IMPORTANT: Mesh-only mode requires a sidecar on the controller pod.
+// Without a sidecar, probes will fail because the top-level Knative service
+// has no endpoints — routing is handled entirely by the mesh VirtualService.
 func (r *Reconciler) reconcileMeshOnlyIngress(ctx context.Context, ing *v1alpha1.Ingress) error {
 	logger := logging.FromContext(ctx)
-	logger.Info("Gateways disabled, reconciling mesh-only ingress")
+	logger.Info("Gateways disabled, reconciling mesh-only ingress. " +
+		"Ensure the controller has an Istio sidecar for mesh probing to work.")
 
 	// Create only mesh VirtualServices with empty gateway names.
 	emptyGateways := map[v1alpha1.IngressVisibility]sets.Set[string]{

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -1034,7 +1034,6 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 								Name:       config.KnativeIngressGateway,
 								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
 							}},
-							EnableGateways: true,
 						},
 						Network: &netconfig.Config{
 							HTTPProtocol:      netconfig.HTTPDisabled,
@@ -1254,7 +1253,6 @@ func TestReconcile_ClusterLocalDomainTLS(t *testing.T) {
 								Name:       config.KnativeLocalGateway,
 								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
 							}},
-							EnableGateways: true,
 						},
 						Network: &netconfig.Config{
 							ClusterLocalDomainTLS: netconfig.EncryptionEnabled,
@@ -1274,7 +1272,8 @@ var emptyGateways = map[v1alpha1.IngressVisibility]sets.Set[string]{
 func meshOnlyConfig() *config.Config {
 	return &config.Config{
 		Istio: &config.Istio{
-			EnableGateways: false,
+			IngressGateways: []config.Gateway{},
+			LocalGateways:   []config.Gateway{},
 		},
 		Network: &netconfig.Config{
 			ExternalDomainTLS: false,
@@ -1656,7 +1655,6 @@ func ReconcilerTestConfig() *config.Config {
 				Name:       config.KnativeIngressGateway,
 				ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
 			}},
-			EnableGateways: true,
 		},
 		Network: &netconfig.Config{
 			ExternalDomainTLS: false,

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -1034,6 +1034,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 								Name:       config.KnativeIngressGateway,
 								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
 							}},
+							EnableGateways: true,
 						},
 						Network: &netconfig.Config{
 							HTTPProtocol:      netconfig.HTTPDisabled,
@@ -1253,11 +1254,260 @@ func TestReconcile_ClusterLocalDomainTLS(t *testing.T) {
 								Name:       config.KnativeLocalGateway,
 								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
 							}},
+							EnableGateways: true,
 						},
 						Network: &netconfig.Config{
 							ClusterLocalDomainTLS: netconfig.EncryptionEnabled,
 						},
 					},
+				},
+			})
+	}))
+}
+
+// emptyGateways is the gateway map used by reconcileMeshOnlyIngress
+var emptyGateways = map[v1alpha1.IngressVisibility]sets.Set[string]{
+	v1alpha1.IngressVisibilityClusterLocal: sets.New[string](),
+	v1alpha1.IngressVisibilityExternalIP:   sets.New[string](),
+}
+
+func meshOnlyConfig() *config.Config {
+	return &config.Config{
+		Istio: &config.Istio{
+			EnableGateways: false,
+		},
+		Network: &netconfig.Config{
+			ExternalDomainTLS: false,
+		},
+	}
+}
+
+func meshOnlyReadyStatus() v1alpha1.IngressStatus {
+	return v1alpha1.IngressStatus{
+		PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+			Ingress: []v1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
+		},
+		PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+			Ingress: []v1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
+		},
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:     v1alpha1.IngressConditionLoadBalancerReady,
+				Status:   corev1.ConditionTrue,
+				Severity: apis.ConditionSeverityError,
+			}, {
+				Type:     v1alpha1.IngressConditionNetworkConfigured,
+				Status:   corev1.ConditionTrue,
+				Severity: apis.ConditionSeverityError,
+			}, {
+				Type:     v1alpha1.IngressConditionReady,
+				Status:   corev1.ConditionTrue,
+				Severity: apis.ConditionSeverityError,
+			}},
+		},
+	}
+}
+
+func meshOnlyReconciledIngress(name string) *v1alpha1.Ingress {
+	return ingressWithStatusAndFinalizers(name, meshOnlyReadyStatus(),
+		[]string{"ingresses.networking.internal.knative.dev"})
+}
+
+func TestReconcile_MeshOnly(t *testing.T) {
+	table := TableTest{{
+		Name: "mesh-only: create new ingress creates only mesh VirtualService",
+		Objects: []runtime.Object{
+			ing("mesh-only-ingress"),
+		},
+		WantCreates: []runtime.Object{
+			resources.MakeMeshVirtualService(insertProbe(ing("mesh-only-ingress")), emptyGateways),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("mesh-only-ingress", ingressFinalizer),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithStatus("mesh-only-ingress", meshOnlyReadyStatus()),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "mesh-only-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "mesh-only-ingress-mesh"),
+		},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(1)},
+		Key:            "test-ns/mesh-only-ingress",
+		CmpOpts:        defaultCmpOptsList,
+	}, {
+		Name:    "mesh-only: VirtualService update failure marks LoadBalancer failed",
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "virtualservices"),
+		},
+		Objects: []runtime.Object{
+			ing("mesh-only-fail"),
+			&v1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mesh-only-fail-mesh",
+					Namespace: testNS,
+					Labels: map[string]string{
+						networking.IngressLabelKey: "mesh-only-fail",
+					},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("mesh-only-fail"))},
+				},
+				Spec: istiov1beta1.VirtualService{},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: resources.MakeMeshVirtualService(insertProbe(ing("mesh-only-fail")), emptyGateways),
+		}},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithStatus("mesh-only-fail",
+				v1alpha1.IngressStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:     v1alpha1.IngressConditionLoadBalancerReady,
+							Reason:   virtualServiceNotReconciled,
+							Severity: apis.ConditionSeverityError,
+							Message:  "failed to update VirtualService: inducing failure for update virtualservices",
+							Status:   corev1.ConditionFalse,
+						}, {
+							Type:   v1alpha1.IngressConditionNetworkConfigured,
+							Status: corev1.ConditionUnknown,
+						}, {
+							Type:     v1alpha1.IngressConditionReady,
+							Status:   corev1.ConditionFalse,
+							Severity: apis.ConditionSeverityError,
+							Reason:   notReconciledReason,
+							Message:  notReconciledMessage,
+						}},
+					},
+				},
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "mesh-only-fail"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to update VirtualService: inducing failure for update virtualservices"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("mesh-only-fail", "ingresses.networking.internal.knative.dev"),
+		},
+		Key:     "test-ns/mesh-only-fail",
+		CmpOpts: defaultCmpOptsList,
+	}, {
+		Name: "mesh-only: reconcile existing VS and delete stale ingress VS",
+		Objects: []runtime.Object{
+			ing("mesh-only-cleanup"),
+			// Existing mesh VS with stale spec
+			&v1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mesh-only-cleanup-mesh",
+					Namespace: testNS,
+					Labels: map[string]string{
+						networking.IngressLabelKey: "mesh-only-cleanup",
+					},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("mesh-only-cleanup"))},
+				},
+				Spec: istiov1beta1.VirtualService{},
+			},
+			// Stale ingress VS that should be deleted in mesh-only mode
+			&v1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mesh-only-cleanup-ingress",
+					Namespace: testNS,
+					Labels: map[string]string{
+						networking.IngressLabelKey: "mesh-only-cleanup",
+					},
+					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("mesh-only-cleanup"))},
+				},
+				Spec: istiov1beta1.VirtualService{},
+			},
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: resources.MakeMeshVirtualService(insertProbe(ing("mesh-only-cleanup")), emptyGateways),
+		}},
+		WantDeletes: []clientgotesting.DeleteActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: testNS,
+				Verb:      "delete",
+				Resource:  v1beta1.SchemeGroupVersion.WithResource("virtualservices"),
+			},
+			Name: "mesh-only-cleanup-ingress",
+		}},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithStatus("mesh-only-cleanup", meshOnlyReadyStatus()),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "mesh-only-cleanup"),
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated VirtualService %s/%s",
+				"test-ns", "mesh-only-cleanup-mesh"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("mesh-only-cleanup", "ingresses.networking.internal.knative.dev"),
+		},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(1)},
+		Key:            "test-ns/mesh-only-cleanup",
+		CmpOpts:        defaultCmpOptsList,
+	}, {
+		Name: "mesh-only: already ready ingress skips probe",
+		Objects: []runtime.Object{
+			meshOnlyReconciledIngress("mesh-only-ready"),
+			resources.MakeMeshVirtualService(insertProbe(ing("mesh-only-ready")), emptyGateways),
+		},
+		Key:            "test-ns/mesh-only-ready",
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(0)},
+		CmpOpts:        defaultCmpOptsList,
+	}, {
+		Name: "mesh-only: ingress with TLS but gateways disabled only creates mesh VS",
+		Objects: []runtime.Object{
+			ingressWithTLS("mesh-only-tls", externalIngressTLS),
+			originSecret("istio-system", "secret0"),
+			ingressService,
+		},
+		WantCreates: []runtime.Object{
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("mesh-only-tls", externalIngressTLS)), emptyGateways),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("mesh-only-tls", ingressFinalizer),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithTLSAndStatus("mesh-only-tls",
+				externalIngressTLS,
+				meshOnlyReadyStatus(),
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "mesh-only-tls"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "mesh-only-tls-mesh"),
+		},
+		PostConditions: []func(*testing.T, *TableRow){proberCalledTimes(1)},
+		Key:            "test-ns/mesh-only-tls",
+		CmpOpts:        defaultCmpOptsList,
+	}, {
+		Name: "mesh-only: delete ingress skips gateway server cleanup",
+		Objects: []runtime.Object{
+			ingressWithFinalizers("mesh-only-delete", nil, []string{ingressFinalizer}, &deletionTime),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("mesh-only-delete", ""),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "mesh-only-delete"),
+		},
+		Key:     "test-ns/mesh-only-delete",
+		CmpOpts: defaultCmpOptsList,
+	}}
+
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		r := &Reconciler{
+			kubeclient:           kubeclient.Get(ctx),
+			istioClientSet:       istioclient.Get(ctx),
+			virtualServiceLister: listers.GetVirtualServiceLister(),
+			gatewayLister:        listers.GetGatewayLister(),
+			statusManager:        ctx.Value(FakeStatusManagerKey).(status.Manager),
+		}
+
+		return ingressreconciler.NewReconciler(ctx, logging.FromContext(ctx), fakenetworkingclient.Get(ctx),
+			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, netconfig.IstioIngressClassName, controller.Options{
+				ConfigStore: &testConfigStore{
+					config: meshOnlyConfig(),
 				},
 			})
 	}))
@@ -1406,6 +1656,7 @@ func ReconcilerTestConfig() *config.Config {
 				Name:       config.KnativeIngressGateway,
 				ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
 			}},
+			EnableGateways: true,
 		},
 		Network: &netconfig.Config{
 			ExternalDomainTLS: false,

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -27,10 +27,13 @@ import (
 	istiov1beta1 "istio.io/api/networking/v1beta1"
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
 	istiolisters "istio.io/client-go/pkg/listers/networking/v1beta1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/net-istio/pkg/reconciler/ingress/config"
 	"knative.dev/net-istio/pkg/reconciler/ingress/resources"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/ingress"
@@ -62,6 +65,18 @@ type gatewayPodTargetLister struct {
 
 func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1alpha1.Ingress) ([]status.ProbeTarget, error) {
 	results := []status.ProbeTarget{}
+
+	// When gateways are explicitly disabled, go directly to mesh-only probing.
+	cfg := config.FromContext(ctx)
+	if !cfg.Istio.EnableGateways {
+		l.logger.Info("Gateways disabled via config, using mesh-only probing")
+		meshTargets, err := l.listMeshProbeTargets(ing)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list mesh probe targets: %w", err)
+		}
+		return meshTargets, nil
+	}
+
 	gatewayQualifiedNames, err := resources.QualifiedGatewayNamesFromContext(ctx, ing)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get gateways for ingress: %w", err)
@@ -74,11 +89,17 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 
 	// Sort the gateway names for a consistent ordering.
 	sort.Strings(gatewayNames)
+	gatewaysFound := false
 	for _, gatewayName := range gatewayNames {
 		gateway, err := l.getGateway(gatewayName)
 		if err != nil {
+			if apierrs.IsNotFound(err) {
+				l.logger.Infof("Skipping Gateway %q because it doesn't exist", gatewayName)
+				continue
+			}
 			return nil, fmt.Errorf("failed to get Gateway %q: %w", gatewayName, err)
 		}
+		gatewaysFound = true
 		targets, err := l.listGatewayTargets(gateway)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list the probing URLs of Gateway %q: %w", gatewayName, err)
@@ -102,6 +123,18 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 			results = append(results, qualifiedTarget)
 		}
 	}
+
+	// If no gateways were found, fall back to mesh-only mode:
+	// probe the destination service pods directly to verify reachability.
+	if !gatewaysFound {
+		l.logger.Info("No gateways found, falling back to mesh-only probing of destination services")
+		meshTargets, err := l.listMeshProbeTargets(ing)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list mesh probe targets: %w", err)
+		}
+		results = append(results, meshTargets...)
+	}
+
 	return results, nil
 }
 
@@ -193,4 +226,94 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1beta1.Gateway) ([
 		}
 	}
 	return targets, nil
+}
+
+// listMeshProbeTargets builds probe targets from the Ingress spec's destination
+// services when no gateways are available (mesh-only mode). It resolves each
+// backend service to its Endpoints and probes the pods directly.
+func (l *gatewayPodTargetLister) listMeshProbeTargets(ing *v1alpha1.Ingress) ([]status.ProbeTarget, error) {
+	results := []status.ProbeTarget{}
+	seen := sets.New[string]()
+
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil || len(rule.Hosts) == 0 {
+			continue
+		}
+		// Use the first host for the probe URL Host header.
+		host := rule.Hosts[0]
+
+		for _, path := range rule.HTTP.Paths {
+			for _, split := range path.Splits {
+				key := split.ServiceNamespace + "/" + split.ServiceName + ":" + split.ServicePort.String()
+				if seen.Has(key) {
+					continue
+				}
+				seen.Insert(key)
+
+				svc, err := l.serviceLister.Services(split.ServiceNamespace).Get(split.ServiceName)
+				if err != nil {
+					l.logger.Infof("Skipping service %s/%s for mesh probing: failed to get Service: %v",
+						split.ServiceNamespace, split.ServiceName, err)
+					continue
+				}
+
+				// Resolve the service port to a port name and number.
+				var portName string
+				var svcPortNumber int32
+				if split.ServicePort.Type == intstr.Int {
+					svcPortNumber = int32(split.ServicePort.IntValue())
+					portName, err = k8s.NameForPortNumber(svc, svcPortNumber)
+					if err != nil {
+						l.logger.Infof("Skipping service %s/%s port %d for mesh probing: %v",
+							split.ServiceNamespace, split.ServiceName, svcPortNumber, err)
+						continue
+					}
+				} else {
+					portName = split.ServicePort.String()
+					for _, p := range svc.Spec.Ports {
+						if p.Name == portName {
+							svcPortNumber = p.Port
+							break
+						}
+					}
+					if svcPortNumber == 0 {
+						l.logger.Infof("Skipping service %s/%s port %q for mesh probing: port name not found in Service",
+							split.ServiceNamespace, split.ServiceName, portName)
+						continue
+					}
+				}
+
+				endpoints, err := l.endpointsLister.Endpoints(split.ServiceNamespace).Get(split.ServiceName)
+				if err != nil {
+					l.logger.Infof("Skipping service %s/%s for mesh probing: failed to get Endpoints: %v",
+						split.ServiceNamespace, split.ServiceName, err)
+					continue
+				}
+
+				svcPort := strconv.Itoa(int(svcPortNumber))
+				for _, sub := range endpoints.Subsets {
+					podPort, err := k8s.PortNumberForName(sub, portName)
+					if err != nil {
+						l.logger.Infof("Skipping Subset for service %s/%s: port name %q not found in Endpoints",
+							split.ServiceNamespace, split.ServiceName, portName)
+						continue
+					}
+					target := status.ProbeTarget{
+						PodIPs:  sets.New[string](),
+						PodPort: strconv.Itoa(int(podPort)),
+						Port:    svcPort,
+						URLs: []*url.URL{{
+							Scheme: "http",
+							Host:   host + ":" + svcPort,
+						}},
+					}
+					for _, addr := range sub.Addresses {
+						target.PodIPs.Insert(addr.IP)
+					}
+					results = append(results, target)
+				}
+			}
+		}
+	}
+	return results, nil
 }

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -68,7 +68,7 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 
 	// When gateways are explicitly disabled, go directly to mesh-only probing.
 	cfg := config.FromContext(ctx)
-	if !cfg.Istio.EnableGateways {
+	if !cfg.Istio.GatewaysEnabled() {
 		l.logger.Info("Gateways disabled via config, using mesh-only probing")
 		meshTargets, err := l.listMeshProbeTargets(ing)
 		if err != nil {

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -19,9 +19,12 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
+	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	istiov1beta1 "istio.io/api/networking/v1beta1"
@@ -29,7 +32,6 @@ import (
 	istiolisters "istio.io/client-go/pkg/listers/networking/v1beta1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -61,6 +63,10 @@ type gatewayPodTargetLister struct {
 	gatewayLister   istiolisters.GatewayLister
 	endpointsLister corev1listers.EndpointsLister
 	serviceLister   corev1listers.ServiceLister
+
+	sidecarCheckOnce sync.Once
+	sidecarPresent   bool
+	detectSidecarFn  func() bool // nil → use default TCP check
 }
 
 func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1alpha1.Ingress) ([]status.ProbeTarget, error) {
@@ -69,12 +75,9 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 	// When gateways are explicitly disabled, go directly to mesh-only probing.
 	cfg := config.FromContext(ctx)
 	if !cfg.Istio.GatewaysEnabled() {
-		l.logger.Info("Gateways disabled via config, using mesh-only probing")
-		meshTargets, err := l.listMeshProbeTargets(ing)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list mesh probe targets: %w", err)
-		}
-		return meshTargets, nil
+		l.logger.Info("Gateways disabled via config, using mesh-only probing. " +
+			"A sidecar on the controller is required for probes to reach the mesh VirtualService.")
+		return l.listMeshProbeTargets(ing), nil
 	}
 
 	gatewayQualifiedNames, err := resources.QualifiedGatewayNamesFromContext(ctx, ing)
@@ -127,12 +130,9 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 	// If no gateways were found, fall back to mesh-only mode:
 	// probe the destination service pods directly to verify reachability.
 	if !gatewaysFound {
-		l.logger.Info("No gateways found, falling back to mesh-only probing of destination services")
-		meshTargets, err := l.listMeshProbeTargets(ing)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list mesh probe targets: %w", err)
-		}
-		results = append(results, meshTargets...)
+		l.logger.Info("No gateways found, falling back to mesh-only probing. " +
+			"A sidecar on the controller is required for probes to reach the mesh VirtualService.")
+		results = append(results, l.listMeshProbeTargets(ing)...)
 	}
 
 	return results, nil
@@ -228,10 +228,30 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1beta1.Gateway) ([
 	return targets, nil
 }
 
-// listMeshProbeTargets builds probe targets from the Ingress spec's destination
-// services when no gateways are available (mesh-only mode). It resolves each
-// backend service to its Endpoints and probes the pods directly.
-func (l *gatewayPodTargetLister) listMeshProbeTargets(ing *v1alpha1.Ingress) ([]status.ProbeTarget, error) {
+// listMeshProbeTargets builds probe targets for mesh-only mode by using the
+// rule hosts from the Ingress spec as dial targets. The controller's sidecar
+// intercepts outbound traffic, matches the authority against the mesh
+// VirtualService, and routes to the correct revision service.
+//
+// If no sidecar is detected on the controller, probing is skipped and an
+// empty list is returned. This causes the ingress to be marked ready
+// immediately after VirtualService reconciliation.
+func (l *gatewayPodTargetLister) listMeshProbeTargets(ing *v1alpha1.Ingress) []status.ProbeTarget {
+	l.sidecarCheckOnce.Do(func() {
+		l.sidecarPresent = l.detectSidecar()
+		if l.sidecarPresent {
+			l.logger.Info("Istio sidecar detected on controller, mesh probing enabled.")
+		} else {
+			l.logger.Warn("No Istio sidecar detected on controller. " +
+				"Mesh probing is disabled — ingress will be marked ready after VirtualService reconciliation. " +
+				"To enable mesh probing, inject an Istio sidecar into the controller pod.")
+		}
+	})
+
+	if !l.sidecarPresent {
+		return nil
+	}
+
 	results := []status.ProbeTarget{}
 	seen := sets.New[string]()
 
@@ -239,81 +259,43 @@ func (l *gatewayPodTargetLister) listMeshProbeTargets(ing *v1alpha1.Ingress) ([]
 		if rule.HTTP == nil || len(rule.Hosts) == 0 {
 			continue
 		}
-		// Use the first host for the probe URL Host header.
+
 		host := rule.Hosts[0]
-
-		for _, path := range rule.HTTP.Paths {
-			for _, split := range path.Splits {
-				key := split.ServiceNamespace + "/" + split.ServiceName + ":" + split.ServicePort.String()
-				if seen.Has(key) {
-					continue
-				}
-				seen.Insert(key)
-
-				svc, err := l.serviceLister.Services(split.ServiceNamespace).Get(split.ServiceName)
-				if err != nil {
-					l.logger.Infof("Skipping service %s/%s for mesh probing: failed to get Service: %v",
-						split.ServiceNamespace, split.ServiceName, err)
-					continue
-				}
-
-				// Resolve the service port to a port name and number.
-				var portName string
-				var svcPortNumber int32
-				if split.ServicePort.Type == intstr.Int {
-					svcPortNumber = int32(split.ServicePort.IntValue())
-					portName, err = k8s.NameForPortNumber(svc, svcPortNumber)
-					if err != nil {
-						l.logger.Infof("Skipping service %s/%s port %d for mesh probing: %v",
-							split.ServiceNamespace, split.ServiceName, svcPortNumber, err)
-						continue
-					}
-				} else {
-					portName = split.ServicePort.String()
-					for _, p := range svc.Spec.Ports {
-						if p.Name == portName {
-							svcPortNumber = p.Port
-							break
-						}
-					}
-					if svcPortNumber == 0 {
-						l.logger.Infof("Skipping service %s/%s port %q for mesh probing: port name not found in Service",
-							split.ServiceNamespace, split.ServiceName, portName)
-						continue
-					}
-				}
-
-				endpoints, err := l.endpointsLister.Endpoints(split.ServiceNamespace).Get(split.ServiceName)
-				if err != nil {
-					l.logger.Infof("Skipping service %s/%s for mesh probing: failed to get Endpoints: %v",
-						split.ServiceNamespace, split.ServiceName, err)
-					continue
-				}
-
-				svcPort := strconv.Itoa(int(svcPortNumber))
-				for _, sub := range endpoints.Subsets {
-					podPort, err := k8s.PortNumberForName(sub, portName)
-					if err != nil {
-						l.logger.Infof("Skipping Subset for service %s/%s: port name %q not found in Endpoints",
-							split.ServiceNamespace, split.ServiceName, portName)
-						continue
-					}
-					target := status.ProbeTarget{
-						PodIPs:  sets.New[string](),
-						PodPort: strconv.Itoa(int(podPort)),
-						Port:    svcPort,
-						URLs: []*url.URL{{
-							Scheme: "http",
-							Host:   host + ":" + svcPort,
-						}},
-					}
-					for _, addr := range sub.Addresses {
-						target.PodIPs.Insert(addr.IP)
-					}
-					results = append(results, target)
-				}
-			}
+		if seen.Has(host) {
+			continue
 		}
+		seen.Insert(host)
+
+		port := "80"
+		if len(rule.HTTP.Paths) > 0 && len(rule.HTTP.Paths[0].Splits) > 0 {
+			port = rule.HTTP.Paths[0].Splits[0].ServicePort.String()
+		}
+
+		results = append(results, status.ProbeTarget{
+			PodIPs:  sets.New[string](host),
+			PodPort: port,
+			Port:    port,
+			URLs: []*url.URL{{
+				Scheme: "http",
+				Host:   host + ":" + port,
+			}},
+		})
 	}
-	return results, nil
+	return results
+}
+
+// detectSidecar checks if an Istio sidecar is present and ready on the
+// controller pod. Uses detectSidecarFn if set (for testing), otherwise
+// queries the pilot-agent health endpoint at localhost:15021/healthz/ready.
+func (l *gatewayPodTargetLister) detectSidecar() bool {
+	if l.detectSidecarFn != nil {
+		return l.detectSidecarFn()
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://localhost:15021/healthz/ready")
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
 }

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -35,8 +35,11 @@ import (
 	"go.uber.org/zap/zaptest"
 	istiolisters "istio.io/client-go/pkg/listers/networking/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
@@ -1619,6 +1622,139 @@ func TestListProbeTargets(t *testing.T) {
 			Port:    "8080",
 			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:8080"}},
 		}},
+	}, {
+		name: "mesh-only mode - gateway not found, probes destination service",
+		ingressGateways: []config.Gateway{{
+			Name:      "gateway",
+			Namespace: "default",
+		}},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1beta1.Gateway{}, // No gateways exist
+		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-service",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "http",
+						Port: 80,
+					}},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpointses: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-service",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Ports: []v1.EndpointPort{{
+						Name: "http",
+						Port: 8080,
+					}},
+					Addresses: []v1.EndpointAddress{{
+						IP: "10.0.0.1",
+					}, {
+						IP: "10.0.0.2",
+					}},
+				}},
+			}},
+		},
+		ingress: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "whatever",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"my-service.default.svc.cluster.local",
+					},
+					Visibility: v1alpha1.IngressVisibilityClusterLocal,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      "my-service",
+									ServiceNamespace: "default",
+									ServicePort:      intstr.FromInt32(80),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		results: []status.ProbeTarget{{
+			PodIPs:  sets.New("10.0.0.1", "10.0.0.2"),
+			PodPort: "8080",
+			Port:    "80",
+			URLs:    []*url.URL{{Scheme: "http", Host: "my-service.default.svc.cluster.local:80"}},
+		}},
+	}, {
+		name: "mesh-only mode - gateway not found, no destination endpoints",
+		ingressGateways: []config.Gateway{{
+			Name:      "gateway",
+			Namespace: "default",
+		}},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1beta1.Gateway{}, // No gateways exist
+		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-service",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "http",
+						Port: 80,
+					}},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpointses: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-service",
+				},
+				Subsets: []v1.EndpointSubset{},
+			}},
+		},
+		ingress: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "whatever",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"my-service.default.svc.cluster.local",
+					},
+					Visibility: v1alpha1.IngressVisibilityClusterLocal,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      "my-service",
+									ServiceNamespace: "default",
+									ServicePort:      intstr.FromInt32(80),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		results: []status.ProbeTarget{},
 	}}
 
 	for _, test := range tests {
@@ -1633,6 +1769,7 @@ func TestListProbeTargets(t *testing.T) {
 				Istio: &config.Istio{
 					IngressGateways: test.ingressGateways,
 					LocalGateways:   test.localGateways,
+					EnableGateways:  true,
 				},
 			})
 			results, err := lister.ListProbeTargets(ctx, test.ingress)
@@ -1645,6 +1782,110 @@ func TestListProbeTargets(t *testing.T) {
 			}
 			if len(test.results)+len(results) > 0 { // consider nil map == empty map
 				// Sort by port number
+				sort.Slice(results, func(i, j int) bool {
+					return results[i].Port < results[j].Port
+				})
+				if diff := cmp.Diff(test.results, results); diff != "" {
+					t.Error("Unexpected probe targets (-want +got):", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestListProbeTargets_GatewaysDisabledViaConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		serviceLister   corev1listers.ServiceLister
+		endpointsLister corev1listers.EndpointsLister
+		ingress         *v1alpha1.Ingress
+		results         []status.ProbeTarget
+	}{{
+		name: "gateways disabled via config - probes destination service directly",
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-service",
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "http",
+						Port: 80,
+					}},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpointses: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-service",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Ports: []v1.EndpointPort{{
+						Name: "http",
+						Port: 8080,
+					}},
+					Addresses: []v1.EndpointAddress{{
+						IP: "10.0.0.1",
+					}},
+				}},
+			}},
+		},
+		ingress: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "whatever",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"my-service.default.svc.cluster.local",
+					},
+					Visibility: v1alpha1.IngressVisibilityClusterLocal,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      "my-service",
+									ServiceNamespace: "default",
+									ServicePort:      intstr.FromInt32(80),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		results: []status.ProbeTarget{{
+			PodIPs:  sets.New("10.0.0.1"),
+			PodPort: "8080",
+			Port:    "80",
+			URLs:    []*url.URL{{Scheme: "http", Host: "my-service.default.svc.cluster.local:80"}},
+		}},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lister := gatewayPodTargetLister{
+				logger:          zaptest.NewLogger(t).Sugar(),
+				gatewayLister:   &fakeGatewayLister{}, // no gateways needed
+				endpointsLister: test.endpointsLister,
+				serviceLister:   test.serviceLister,
+			}
+			// EnableGateways is false - should go directly to mesh probing
+			ctx := config.ToContext(context.Background(), &config.Config{
+				Istio: &config.Istio{
+					EnableGateways: false,
+				},
+			})
+			results, err := lister.ListProbeTargets(ctx, test.ingress)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(test.results)+len(results) > 0 {
 				sort.Slice(results, func(i, j int) bool {
 					return results[i].Port < results[j].Port
 				})
@@ -1702,7 +1943,7 @@ func (l *fakeGatewayNamespaceLister) Get(name string) (*v1beta1.Gateway, error) 
 			return gateway, nil
 		}
 	}
-	return nil, errors.New("not found")
+	return nil, apierrs.NewNotFound(schema.GroupResource{Group: "networking.istio.io", Resource: "gateways"}, name)
 }
 
 type fakeEndpointsLister struct {
@@ -1751,8 +1992,19 @@ func (l *fakeServiceLister) List(selector labels.Selector) ([]*v1.Service, error
 }
 
 func (l *fakeServiceLister) Services(_ string) corev1listers.ServiceNamespaceLister {
-	log.Panic("not implemented")
-	return nil
+	return l
+}
+
+func (l *fakeServiceLister) Get(name string) (*v1.Service, error) {
+	if l.fails {
+		return nil, errors.New("failed to get Service")
+	}
+	for _, svc := range l.services {
+		if svc.Name == name {
+			return svc, nil
+		}
+	}
+	return nil, errors.New("not found")
 }
 
 func (l *fakeServiceLister) GetPodServices(_ *v1.Pod) ([]*v1.Service, error) {

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -1623,7 +1623,7 @@ func TestListProbeTargets(t *testing.T) {
 			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:8080"}},
 		}},
 	}, {
-		name: "mesh-only mode - gateway not found, probes destination service",
+		name: "mesh-only mode - gateway not found, probes via rule host",
 		ingressGateways: []config.Gateway{{
 			Name:      "gateway",
 			Namespace: "default",
@@ -1631,39 +1631,8 @@ func TestListProbeTargets(t *testing.T) {
 		gatewayLister: &fakeGatewayLister{
 			gateways: []*v1beta1.Gateway{}, // No gateways exist
 		},
-		serviceLister: &fakeServiceLister{
-			services: []*v1.Service{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-service",
-				},
-				Spec: v1.ServiceSpec{
-					Ports: []v1.ServicePort{{
-						Name: "http",
-						Port: 80,
-					}},
-				},
-			}},
-		},
-		endpointsLister: &fakeEndpointsLister{
-			endpointses: []*v1.Endpoints{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-service",
-				},
-				Subsets: []v1.EndpointSubset{{
-					Ports: []v1.EndpointPort{{
-						Name: "http",
-						Port: 8080,
-					}},
-					Addresses: []v1.EndpointAddress{{
-						IP: "10.0.0.1",
-					}, {
-						IP: "10.0.0.2",
-					}},
-				}},
-			}},
-		},
+		serviceLister:   &fakeServiceLister{},
+		endpointsLister: &fakeEndpointsLister{},
 		ingress: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
@@ -1679,7 +1648,7 @@ func TestListProbeTargets(t *testing.T) {
 						Paths: []v1alpha1.HTTPIngressPath{{
 							Splits: []v1alpha1.IngressBackendSplit{{
 								IngressBackend: v1alpha1.IngressBackend{
-									ServiceName:      "my-service",
+									ServiceName:      "my-service-00001",
 									ServiceNamespace: "default",
 									ServicePort:      intstr.FromInt32(80),
 								},
@@ -1691,13 +1660,13 @@ func TestListProbeTargets(t *testing.T) {
 			},
 		},
 		results: []status.ProbeTarget{{
-			PodIPs:  sets.New("10.0.0.1", "10.0.0.2"),
-			PodPort: "8080",
+			PodIPs:  sets.New("my-service.default.svc.cluster.local"),
+			PodPort: "80",
 			Port:    "80",
 			URLs:    []*url.URL{{Scheme: "http", Host: "my-service.default.svc.cluster.local:80"}},
 		}},
 	}, {
-		name: "mesh-only mode - gateway not found, no destination endpoints",
+		name: "mesh-only mode - gateway not found, multiple rules deduplicated",
 		ingressGateways: []config.Gateway{{
 			Name:      "gateway",
 			Namespace: "default",
@@ -1705,29 +1674,8 @@ func TestListProbeTargets(t *testing.T) {
 		gatewayLister: &fakeGatewayLister{
 			gateways: []*v1beta1.Gateway{}, // No gateways exist
 		},
-		serviceLister: &fakeServiceLister{
-			services: []*v1.Service{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-service",
-				},
-				Spec: v1.ServiceSpec{
-					Ports: []v1.ServicePort{{
-						Name: "http",
-						Port: 80,
-					}},
-				},
-			}},
-		},
-		endpointsLister: &fakeEndpointsLister{
-			endpointses: []*v1.Endpoints{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-service",
-				},
-				Subsets: []v1.EndpointSubset{},
-			}},
-		},
+		serviceLister:   &fakeServiceLister{},
+		endpointsLister: &fakeEndpointsLister{},
 		ingress: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
@@ -1743,7 +1691,24 @@ func TestListProbeTargets(t *testing.T) {
 						Paths: []v1alpha1.HTTPIngressPath{{
 							Splits: []v1alpha1.IngressBackendSplit{{
 								IngressBackend: v1alpha1.IngressBackend{
-									ServiceName:      "my-service",
+									ServiceName:      "my-service-00001",
+									ServiceNamespace: "default",
+									ServicePort:      intstr.FromInt32(80),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}, {
+					Hosts: []string{
+						"my-service.default.svc.cluster.local",
+					},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      "my-service-00001",
 									ServiceNamespace: "default",
 									ServicePort:      intstr.FromInt32(80),
 								},
@@ -1754,7 +1719,12 @@ func TestListProbeTargets(t *testing.T) {
 				}},
 			},
 		},
-		results: []status.ProbeTarget{},
+		results: []status.ProbeTarget{{
+			PodIPs:  sets.New("my-service.default.svc.cluster.local"),
+			PodPort: "80",
+			Port:    "80",
+			URLs:    []*url.URL{{Scheme: "http", Host: "my-service.default.svc.cluster.local:80"}},
+		}},
 	}}
 
 	for _, test := range tests {
@@ -1764,7 +1734,11 @@ func TestListProbeTargets(t *testing.T) {
 				gatewayLister:   test.gatewayLister,
 				endpointsLister: test.endpointsLister,
 				serviceLister:   test.serviceLister,
+				sidecarPresent:  true,
+				detectSidecarFn: func() bool { return true },
 			}
+			// Mark sidecar check as already done so mesh probing works in tests.
+			lister.sidecarCheckOnce.Do(func() {})
 			ctx := config.ToContext(context.Background(), &config.Config{
 				Istio: &config.Istio{
 					IngressGateways: test.ingressGateways,
@@ -1795,43 +1769,16 @@ func TestListProbeTargets(t *testing.T) {
 func TestListProbeTargets_GatewaysDisabledViaConfig(t *testing.T) {
 	tests := []struct {
 		name            string
+		sidecarPresent  bool
 		serviceLister   corev1listers.ServiceLister
 		endpointsLister corev1listers.EndpointsLister
 		ingress         *v1alpha1.Ingress
 		results         []status.ProbeTarget
 	}{{
-		name: "gateways disabled via config - probes destination service directly",
-		serviceLister: &fakeServiceLister{
-			services: []*v1.Service{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-service",
-				},
-				Spec: v1.ServiceSpec{
-					Ports: []v1.ServicePort{{
-						Name: "http",
-						Port: 80,
-					}},
-				},
-			}},
-		},
-		endpointsLister: &fakeEndpointsLister{
-			endpointses: []*v1.Endpoints{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-service",
-				},
-				Subsets: []v1.EndpointSubset{{
-					Ports: []v1.EndpointPort{{
-						Name: "http",
-						Port: 8080,
-					}},
-					Addresses: []v1.EndpointAddress{{
-						IP: "10.0.0.1",
-					}},
-				}},
-			}},
-		},
+		name:            "gateways disabled, sidecar present - probes via rule host",
+		sidecarPresent:  true,
+		serviceLister:   &fakeServiceLister{},
+		endpointsLister: &fakeEndpointsLister{},
 		ingress: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
@@ -1847,7 +1794,7 @@ func TestListProbeTargets_GatewaysDisabledViaConfig(t *testing.T) {
 						Paths: []v1alpha1.HTTPIngressPath{{
 							Splits: []v1alpha1.IngressBackendSplit{{
 								IngressBackend: v1alpha1.IngressBackend{
-									ServiceName:      "my-service",
+									ServiceName:      "my-service-00001",
 									ServiceNamespace: "default",
 									ServicePort:      intstr.FromInt32(80),
 								},
@@ -1859,22 +1806,56 @@ func TestListProbeTargets_GatewaysDisabledViaConfig(t *testing.T) {
 			},
 		},
 		results: []status.ProbeTarget{{
-			PodIPs:  sets.New("10.0.0.1"),
-			PodPort: "8080",
+			PodIPs:  sets.New("my-service.default.svc.cluster.local"),
+			PodPort: "80",
 			Port:    "80",
 			URLs:    []*url.URL{{Scheme: "http", Host: "my-service.default.svc.cluster.local:80"}},
 		}},
+	}, {
+		name:            "gateways disabled, no sidecar - probing skipped",
+		sidecarPresent:  false,
+		serviceLister:   &fakeServiceLister{},
+		endpointsLister: &fakeEndpointsLister{},
+		ingress: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "whatever",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"my-service.default.svc.cluster.local",
+					},
+					Visibility: v1alpha1.IngressVisibilityClusterLocal,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      "my-service-00001",
+									ServiceNamespace: "default",
+									ServicePort:      intstr.FromInt32(80),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		results: nil,
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			lister := gatewayPodTargetLister{
 				logger:          zaptest.NewLogger(t).Sugar(),
-				gatewayLister:   &fakeGatewayLister{}, // no gateways needed
+				gatewayLister:   &fakeGatewayLister{},
 				endpointsLister: test.endpointsLister,
 				serviceLister:   test.serviceLister,
+				sidecarPresent:  test.sidecarPresent,
+				detectSidecarFn: func() bool { return test.sidecarPresent },
 			}
-			// Empty gateway lists - should go directly to mesh probing
+			lister.sidecarCheckOnce.Do(func() {})
 			ctx := config.ToContext(context.Background(), &config.Config{
 				Istio: &config.Istio{
 					IngressGateways: []config.Gateway{},

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -1769,7 +1769,6 @@ func TestListProbeTargets(t *testing.T) {
 				Istio: &config.Istio{
 					IngressGateways: test.ingressGateways,
 					LocalGateways:   test.localGateways,
-					EnableGateways:  true,
 				},
 			})
 			results, err := lister.ListProbeTargets(ctx, test.ingress)
@@ -1875,10 +1874,11 @@ func TestListProbeTargets_GatewaysDisabledViaConfig(t *testing.T) {
 				endpointsLister: test.endpointsLister,
 				serviceLister:   test.serviceLister,
 			}
-			// EnableGateways is false - should go directly to mesh probing
+			// Empty gateway lists - should go directly to mesh probing
 			ctx := config.ToContext(context.Background(), &config.Config{
 				Istio: &config.Istio{
-					EnableGateways: false,
+					IngressGateways: []config.Gateway{},
+					LocalGateways:   []config.Gateway{},
 				},
 			})
 			results, err := lister.ListProbeTargets(ctx, test.ingress)


### PR DESCRIPTION
Add a new `enable-gateways` key to the `config-istio` ConfigMap that allows disabling Istio Gateway creation and reconciliation. When set to "false", the ingress reconciler takes a simplified mesh-only path:

- Only mesh VirtualServices are created (no ingress VS, no Gateways)
- TLS secret copying and gateway server management are skipped
- Readiness probing targets destination service pods directly
- LoadBalancer status reports MeshOnly for both public and private
- FinalizeKind skips gateway server cleanup

This enables using net-istio purely for service-to-service mesh communication without requiring Istio ingress gateway infrastructure.

The option defaults to "true" for full backward compatibility.

<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add `EnableGateways` bool field to Istio config struct, parsed from `enable-gateways` ConfigMap key (defaults to `true`)
- :gift: Add `reconcileMeshOnlyIngress` path that creates only mesh VirtualServices when gateways are disabled
- :gift: Add mesh-only probing in `ListProbeTargets` that targets destination service pods directly when gateways are disabled
- :broom: Guard  FinalizeKind gateway server cleanup behind `EnableGateways` check

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Add `enable-gateways` key to `config-istio` ConfigMap. When set to "false", net-istio operates in mesh-only mode: no Istio Gateways are created, only mesh VirtualServices are reconciled, and readiness probing targets destination service pods directly. This enables using Knative with net-istio for service-to-service mesh communication without requiring Istio ingress gateway infrastructure. Defaults to "true" for backward compatibility.
```

TBD - will open a docs PR to document the new `enable-gateways` config option.